### PR TITLE
Make packages explanation specific to the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 
 ## Packages
 
-Cycle.js is comprised of many specialized packages. This repository contains all these packages, e.g., the npm package `@cycle/foo` lives in the directory `foo`. Below you will find a summary of each package.
+Cycle.js is comprised of many specialized packages. This repository contains all these packages, e.g., the npm package `@cycle/base` lives in the directory `base`. Below you will find a summary of each package.
 
 | Package | Version | Dependencies | DevDependencies |
 |--------|-------|------------|----------|


### PR DESCRIPTION
Really minor detail but: `@cycle/foo` can be misleading given there is no real `@cycle/foo` package or `foo` directory. For really quickly understanding the sentence I would use a specific package included in the project, like `base`.