### PR TITLE
Remove jspm from package.json

### DIFF
--- a/http/package.json
+++ b/http/package.json
@@ -25,9 +25,6 @@
     "saucie": "^1.4.1",
     "xstream": "5.x.x"
   },
-  "jspm": {
-    "main": "dist/cycle-http-driver"
-  },
   "browserify-shim": {
     "xstream": "global:xstream"
   },


### PR DESCRIPTION
The jspm's main file is incorrect, it shouldn't be using the compiled version, this also fix #237.
We don't need this as jspm will automatically look for main by default.