### PR TITLE
Add example for TSX #350

### DIFF
--- a/examples/tsx-seconds-elapsed/.babelrc
+++ b/examples/tsx-seconds-elapsed/.babelrc
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "syntax-jsx",
+    ["transform-react-jsx", {"pragma": "html"}]
+  ]
+}

--- a/examples/tsx-seconds-elapsed/.gitignore
+++ b/examples/tsx-seconds-elapsed/.gitignore
@@ -1,0 +1,4 @@
+dist
+node_modules
+lib
+typings

--- a/examples/tsx-seconds-elapsed/index.html
+++ b/examples/tsx-seconds-elapsed/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+  <meta name="description" content="Cycle.js example - Seconds Elapsed (TSX)"/>
+  <title>Cycle.js example - Seconds Elapsed (TSX)</title>
+</head>
+<body>
+  <div id="main-container"></div>
+  <script src="./dist/main.js"></script>
+</body>
+</html>

--- a/examples/tsx-seconds-elapsed/package.json
+++ b/examples/tsx-seconds-elapsed/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "example",
+  "version": "0.0.0",
+  "private": true,
+  "author": "Kay Plößer",
+  "license": "MIT",
+  "dependencies": {
+    "@cycle/xstream-run": "3.0.x",
+    "@cycle/dom": "10.0.0-rc32",
+    "snabbdom-jsx": "0.3.0",
+    "xstream": "5.0.x"
+  },
+  "devDependencies": {
+    "babel-plugin-syntax-jsx": "^6.8.0",
+    "babel-plugin-transform-react-jsx": "^6.8.0",
+    "babel-register": "^6.4.3",
+    "babelify": "^7.2.0",
+    "browserify": "11.0.1",
+    "mkdirp": "0.5.x",
+    "typescript": "1.8.7",
+    "typings": "^1.0.4"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "prebrowserify": "mkdirp dist && typings install && tsc",
+    "browserify": "browserify lib/index.jsx -t babelify --outfile dist/main.js",
+    "start": "npm install && npm run browserify && echo 'OPEN index.html IN YOUR BROWSER'"
+  }
+}

--- a/examples/tsx-seconds-elapsed/src/index.tsx
+++ b/examples/tsx-seconds-elapsed/src/index.tsx
@@ -1,0 +1,21 @@
+const {html} = require('snabbdom-jsx');
+import xs from 'xstream';
+import Cycle from '@cycle/xstream-run';
+import {makeDOMDriver} from '@cycle/dom';
+
+interface Sources {
+  DOM: Function
+}
+
+function main(sources : Sources) {
+  return {
+    DOM: xs.periodic(1000).map(i => i + 1).startWith(0)
+      .map(i => <div>Seconds elapsed {i}</div>)
+  };
+}
+
+const drivers : {[name : string] : Function} = {
+  DOM: makeDOMDriver('#main-container')
+};
+
+Cycle.run(main, drivers);

--- a/examples/tsx-seconds-elapsed/tsconfig.json
+++ b/examples/tsx-seconds-elapsed/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "removeComments": false,
+    "preserveConstEnums": true,
+    "sourceMap": true,
+    "declaration": true,
+    "noImplicitAny": true,
+    "suppressImplicitAnyIndexErrors": true,
+    "module": "commonjs",
+    "target": "ES5",
+    "outDir": "lib/",
+    "jsx": "preserve"
+  },
+  "formatCodeOptions": {
+    "indentSize": 2,
+    "tabSize": 2
+  },
+   "files": [
+     "typings/index.d.ts",
+     "src/index.tsx"
+   ]
+}

--- a/examples/tsx-seconds-elapsed/typings.json
+++ b/examples/tsx-seconds-elapsed/typings.json
@@ -1,0 +1,7 @@
+{
+  "globalDependencies": {
+    "es6-shim": "github:DefinitelyTyped/DefinitelyTyped/es6-shim/es6-shim.d.ts#6697d6f7dadbf5773cb40ecda35a76027e0783b2",
+    "react": "registry:dt/react#0.14.0+20160720060442",
+    "require": "github:DefinitelyTyped/DefinitelyTyped/requirejs/require.d.ts#56295f5058cac7ae458540423c50ac2dcf9fc711"
+  }
+}

--- a/typings.json
+++ b/typings.json
@@ -1,0 +1,6 @@
+{
+  "globalDependencies": {
+    "react": "registry:dt/react#0.14.0+20160720060442",
+    "react-dom": "registry:dt/react-dom#0.14.0+20160412154040"
+  }
+}


### PR DESCRIPTION
Tried my luck with it and got it working with Babel and the TypeScript compiler.

I preserve the JSX and let Babel handle the conversion, because `tsc` always emits `createElement`

This has the drawback, that `tsc` completely ignores the JSX and removes the `snabbdom-jsx` imports.

I prevented the removal with `const {html} = require('snabbdom-jsx')` inside the `.tsx` file.

The alternative would be a wrapper for `snabbdom-jsx` that has a `createElement` method (https://github.com/yelouafi/snabbdom-jsx/issues/8#issuecomment-230998185)