### PR TITLE
fix(rxjs-adapter): make most.js streams fail isValidStream test

### DIFF
--- a/rxjs-adapter/package.json
+++ b/rxjs-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cycle/rxjs-adapter",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Cycle.js RxJS 5 Stream Adapter",
   "typings": "lib/index.d.ts",
   "main": "lib/index.js",

--- a/rxjs-adapter/src/index.ts
+++ b/rxjs-adapter/src/index.ts
@@ -39,6 +39,7 @@ const RxJSAdapter: StreamAdapter = {
   isValidStream(stream: any): boolean {
     return (
       typeof stream.subscribe === 'function' &&
+      typeof stream.observe !== 'function' &&
       typeof stream.subscribeOnNext !== 'function' &&
       typeof stream.onValue !== 'function');
   },


### PR DESCRIPTION
Add "stream.observe !== 'function'" to isValidStream test to ensure most.js streams do not evaluate as valid