### PR TITLE
Add support for DOM.select('document') and DOM.select('body').

### DIFF
--- a/dom/package.json
+++ b/dom/package.json
@@ -49,6 +49,7 @@
     "rx": "^4.1.0",
     "rxjs": "^5.0.0-beta.8",
     "saucie": "^1.4.1",
+    "simulant": "^0.2.2",
     "snabbdom-jsx": "^0.3.0",
     "xstream": "5.x.x"
   },

--- a/dom/src/MainDOMSource.ts
+++ b/dom/src/MainDOMSource.ts
@@ -148,6 +148,14 @@ export class MainDOMSource implements DOMSource {
         if (!namespace || namespace.length === 0) {
           return fromEvent(rootElement, eventType, useCapture);
         }
+
+        if (namespace[0] === 'document') {
+          return fromEvent(document, eventType, useCapture);
+        }
+
+        if (namespace[0] === 'body') {
+          return fromEvent(document.body, eventType, useCapture);
+        }
         // Event listener on the top element as an EventDelegator
         const delegators = domSource._delegators;
         const top = scope

--- a/dom/src/fromEvent.ts
+++ b/dom/src/fromEvent.ts
@@ -1,6 +1,6 @@
 import {Stream, Producer, Listener} from 'xstream';
 
-export function fromEvent(element: Element,
+export function fromEvent(element: Element | Document,
                           eventName: string,
                           useCapture = false): Stream<Event> {
   return Stream.create<Event>(<Producer<Event>> {

--- a/dom/test/browser/select.js
+++ b/dom/test/browser/select.js
@@ -4,6 +4,7 @@ let assert = require('assert');
 let Cycle = require('@cycle/rxjs-run').default;
 let CycleDOM = require('../../lib/index');
 let Fixture89 = require('./fixtures/issue-89');
+let simulant = require('simulant');
 let Rx = require('rxjs');
 let {h, svg, div, input, p, span, h2, h3, h4, select, option, makeDOMDriver} = CycleDOM;
 
@@ -202,7 +203,7 @@ describe('DOMSource.select()', function () {
       })
     });
     dispose = run();
-    document.dispatchEvent(new Event('click'));
+    simulant.fire(document, 'click');
   });
 
   it('selects the body element', function (done) {
@@ -227,6 +228,6 @@ describe('DOMSource.select()', function () {
       })
     });
     dispose = run();
-    document.body.dispatchEvent(new Event('click'));
+    simulant.fire(document.body, 'click');
   });
 });

--- a/dom/test/browser/select.js
+++ b/dom/test/browser/select.js
@@ -175,4 +175,58 @@ describe('DOMSource.select()', function () {
       });
     run();
   });
+
+  it('selects the document element', function (done) {
+    function app() {
+      return {
+        DOM: Rx.Observable.of(
+          div('hello world')
+        )
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+    function isDocument (element) {
+      return 'body' in element && 'head' in element;
+    }
+
+    let dispose;
+    sources.DOM.select('document').events('click').take(1).subscribe(event => {
+      assert(isDocument(event.target));
+      setTimeout(() => {
+        dispose();
+        done();
+      })
+    });
+    dispose = run();
+    document.dispatchEvent(new Event('click'));
+  });
+
+  it('selects the body element', function (done) {
+    function app() {
+      return {
+        DOM: Rx.Observable.of(
+          div('hello world')
+        )
+      };
+    }
+
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+    let dispose;
+    sources.DOM.select('body').events('click').take(1).subscribe(event => {
+      assert.equal(event.target.tagName, 'BODY');
+      setTimeout(() => {
+        dispose();
+        done();
+      })
+    });
+    dispose = run();
+    document.body.dispatchEvent(new Event('click'));
+  });
 });


### PR DESCRIPTION
Chained calls to select will be ignored if the first select in the chain
is `document` or `body`.

ISSUES CLOSED: #368