### PR TITLE
docs(META): add packages link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@
       Website
     </a>
     <span> | </span>
+    <a href="#packages">
       Packages
+    </a>
     <span> | </span>
     <a href="https://github.com/cyclejs/cyclejs/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22">
       Contribute


### PR DESCRIPTION
Simple readme link for packages.
- [ ] I added new tests for the issue I fixed/built
- [x] I ran `npm test` for the package I'm modifying
- [x] I used `npm run commit` instead of `git commit`

