### PR TITLE
refactor(examples): refactor bmi-nested to use MVI pattern

### DIFF
--- a/examples/bmi-nested/src/LabeledSlider.js
+++ b/examples/bmi-nested/src/LabeledSlider.js
@@ -1,24 +1,39 @@
 import xs from 'xstream';
 import {div, span, input} from '@cycle/dom';
+import isolate from '@cycle/isolate';
 
-function LabeledSlider({DOM, props$}) {
-  let initialValue$ = props$.map(props => props.initial).take(1);
-  let newValue$ = DOM.select('.slider').events('input').map(ev => ev.target.value);
-  let value$ = xs.merge(initialValue$, newValue$).remember();
+function intent(DOMSource) {
+  return DOMSource.select('.slider').events('input').map(ev => ev.target.value);
+};
 
-  let vtree$ = xs.combine(props$, value$).map(([props, value]) =>
+function model(newValue$, props$) {
+  let initialValue$ = props$.map((props) => props.initial).take(1);
+  return xs.merge(initialValue$, newValue$).remember();
+};
+
+function view(props$, value$) {
+  return xs.combine(props$, value$).map(([props, value]) =>
     div('.labeled-slider', [
-      span('.label', [ props.label + ' ' + value + props.unit ]),
+      span('.label', `${props.label} ${value}${props.unit}`),
       input('.slider', {
-        attrs: {type: 'range', min: props.min, max: props.max, value: value}
+        attrs: {type: 'range', min: props.min, max: props.max, value}
       })
     ])
   );
+};
 
+let LabeledSlider = function(sources) {
+  let change$ = intent(sources.DOM);
+  let value$ = model(change$, sources.props$);
+  let vtree$ = view(sources.props$, value$);
   return {
     DOM: vtree$,
-    value$: value$,
+    value: value$
   };
-}
+};
 
-export default LabeledSlider;
+let IsolatedLabeledSlider = function (sources) {
+  return isolate(LabeledSlider)(sources);
+};
+
+export default IsolatedLabeledSlider;


### PR DESCRIPTION
I refactored the bmi-nested example to use the [Model-View-Intent pattern](http://cycle.js.org/model-view-intent.html) during lunch to play around with cyclejs. I also moved `isolate` back to the component (which now [exports a fn which calls isolate](http://cycle.js.org/components.html#Should-I-always-call-isolate-manually)) and changed the sinks keys' name to [not use the stream convention](http://cycle.js.org/components.html#how-to-name-sources-and-sinks).

These changes were for my own learning, but figured I'd make a PR in case you would rather have the example follow this pattern. 

- [ ] I added new tests for the issue I fixed/built
- [x] I ran `npm test` for the package I'm modifying
- [x] I used `npm run commit` instead of `git commit`

