### PR TITLE
fix(most-run): export run funcrion

### DIFF
--- a/most-run/src/index.ts
+++ b/most-run/src/index.ts
@@ -33,8 +33,8 @@ import MostAdapter from '@cycle/most-adapter';
  * Cycle.js program, cleaning up resources used.
  * @function run
  */
-function run<Sources, Sinks>(main: (sources: Sources) => Sinks,
-                             drivers: DriversDefinition): DisposeFunction {
+export function run<Sources, Sinks>(main: (sources: Sources) => Sinks,
+                                    drivers: DriversDefinition): DisposeFunction {
   return CycleBase(main, drivers, {streamAdapter: MostAdapter}).run();
 }
 

--- a/most-run/test/index.js
+++ b/most-run/test/index.js
@@ -4,12 +4,17 @@
 require('creed').shim()
 let assert = require('power-assert');
 let Cycle = require('../lib/index').default;
+let {run} = require('../lib/index');
 let most = require('most');
 let sinon = require('sinon');
 
 describe('Cycle', function () {
   it('should have `run`', function () {
     assert.strictEqual(typeof Cycle.run, 'function');
+  });
+
+  it('should export `run`', function () {
+    assert.strictEqual(run, Cycle.run);
   });
 
   it('should throw if first argument is not a function', function () {

--- a/rx-run/test/cycle.js
+++ b/rx-run/test/cycle.js
@@ -3,12 +3,17 @@
 /* global describe, it */
 let assert = require('assert');
 let Cycle = require('../lib/index').default;
+let {run} = require('../lib/index');
 let Rx = require('rx');
 let sinon = require('sinon');
 
 describe('Cycle', function () {
   it('should have `run`', function () {
     assert.strictEqual(typeof Cycle.run, 'function');
+  });
+
+  it('should export `run`', function () {
+    assert.strictEqual(run, Cycle.run);
   });
 
   it('should throw if first argument is not a function', function () {

--- a/rxjs-run/test/cycle.js
+++ b/rxjs-run/test/cycle.js
@@ -3,12 +3,17 @@
 /* global describe, it */
 let assert = require('assert');
 let Cycle = require('../lib/index').default;
+let {run} = require('../lib/index');
 let Rx = require('rxjs');
 let sinon = require('sinon');
 
 describe('Cycle', function () {
   it('should have `run`', function () {
     assert.strictEqual(typeof Cycle.run, 'function');
+  });
+
+  it('should export `run`', function () {
+    assert.strictEqual(run, Cycle.run);
   });
 
   it('should throw if first argument is not a function', function () {

--- a/xstream-run/test/cycle.js
+++ b/xstream-run/test/cycle.js
@@ -3,6 +3,7 @@
 /* global describe, it */
 let assert = require('assert');
 let Cycle = require('../lib/index').default;
+let {run} = require('../lib/index');
 let xs = require('xstream').default;
 let concat = require('xstream/extra/concat').default;
 let delay = require('xstream/extra/delay').default;
@@ -16,6 +17,10 @@ let window = global.window;
 describe('Cycle', function () {
   it('should have `run`', function () {
     assert.strictEqual(typeof Cycle.run, 'function');
+  });
+
+  it('should export `run`', function () {
+    assert.strictEqual(run, Cycle.run);
   });
 
   it('should throw if first argument is not a function', function () {


### PR DESCRIPTION
- [x] I added new tests for the issue I fixed/built
- [x] I ran `npm test` for the package I'm modifying
- [x] I used `npm run commit` instead of `git commit`

Allows `import {run} from 'most-run'` usage. Also includes corresponding test for all *-run packages to prevent things like #411.