### PR TITLE
Fix isolated component events after parent is recreated

### DIFF
--- a/dom/src/isolateModule.ts
+++ b/dom/src/isolateModule.ts
@@ -15,10 +15,11 @@ export class IsolateModule {
     this.isolatedElements.delete(scope);
   }
 
-  private cleanupVNode({data}: VNode) {
+  private cleanupVNode({data, elm}: VNode) {
     data = data || {};
     const scope = (<any> data).isolate;
-    if (scope) {
+    const isCurrentElm = this.isolatedElements.get(scope) === elm;
+    if (scope && isCurrentElm) {
       this.removeScope(scope);
       if (this.eventDelegators.get(scope)) {
         this.eventDelegators.set(scope, []);

--- a/dom/src/isolateModule.ts
+++ b/dom/src/isolateModule.ts
@@ -15,6 +15,17 @@ export class IsolateModule {
     this.isolatedElements.delete(scope);
   }
 
+  private cleanupVNode({data}: VNode) {
+    data = data || {};
+    const scope = (<any> data).isolate;
+    if (scope) {
+      this.removeScope(scope);
+      if (this.eventDelegators.get(scope)) {
+        this.eventDelegators.set(scope, []);
+      }
+    }
+  }
+
   getIsolatedElement(scope: string) {
     return this.isolatedElements.get(scope);
   }
@@ -82,27 +93,13 @@ export class IsolateModule {
         }
       },
 
-      remove({data}: VNode, cb: Function) {
-        data = data || {};
-        const scope = (<any> data).isolate;
-        if (scope) {
-          self.removeScope(scope);
-          if (self.eventDelegators.get(scope)) {
-            self.eventDelegators.set(scope, []);
-          }
-        }
+      remove(vNode: VNode, cb: Function) {
+        self.cleanupVNode(vNode);
         cb();
       },
 
-      destroy({data}: VNode) {
-        data = data || {};
-        const scope = (<any> data).isolate;
-        if (scope) {
-          self.removeScope(scope);
-          if (self.eventDelegators.get(scope)) {
-            self.eventDelegators.set(scope, []);
-          }
-        }
+      destroy(vNode: VNode) {
+        self.cleanupVNode(vNode);
       }
     };
   }

--- a/dom/test/browser/isolation.js
+++ b/dom/test/browser/isolation.js
@@ -700,7 +700,7 @@ describe('isolation', function () {
     });
 
     let dispose;
-    sources.DOM.select(':root').elements().skip(1).subscribe(function (root) {
+    sources.DOM.select(':root').elements().skip(1).take(3).subscribe(function (root) {
       setTimeout(() => {
         const foo = root.querySelector('.foo');
         if (!foo) return;
@@ -740,7 +740,7 @@ describe('isolation', function () {
     });
 
     let dispose;
-    sources.DOM.select(':root').elements().skip(1).subscribe(function (root) {
+    sources.DOM.select(':root').elements().skip(1).take(3).subscribe(function (root) {
       setTimeout(() => {
         const foo = root.querySelector('.foo');
         if (!foo) return;


### PR DESCRIPTION
Here's a proposed fix to #409.

The added test case fails on master and passes w/ this new change. I'm reusing `isolatedElements` as a way to check whether the element has been replaced by a new instance (when the parent is recreated, the create hook seems to run first and then the old node gets destroyed).