### PR TITLE
fix(http): remove 'remember()' from response$$, not value-over-time

### DIFF
--- a/http/src/http-driver.ts
+++ b/http/src/http-driver.ts
@@ -148,8 +148,7 @@ function makeRequestInputToResponse$(runStreamAdapter: StreamAdapter) {
 export function makeHTTPDriver(): Function {
   function httpDriver(request$: Stream<RequestInput>, runSA: StreamAdapter, name: string): HTTPSource {
     let response$$ = request$
-      .map(makeRequestInputToResponse$(runSA))
-      .remember();
+      .map(makeRequestInputToResponse$(runSA));
     let httpSource = new MainHTTPSource(response$$, runSA, name, []);
     /* tslint:disable:no-empty */
     response$$.addListener({next: () => {}, error: () => {}, complete: () => {}});


### PR DESCRIPTION
- [ ] I added new tests for the issue I fixed/built
- [X] I ran `npm test` for the package I'm modifying
- [X] I used `npm run commit` instead of `git commit`

There is no reason to represent response$$ using a MemoryStream, it is not a value-over-time, HTTP responses are events