### PR TITLE
fix(rxjs-adapter): fixes isValidStream, broken by xstream v6.3

### DIFF
--- a/rxjs-adapter/src/index.ts
+++ b/rxjs-adapter/src/index.ts
@@ -39,6 +39,7 @@ const RxJSAdapter: StreamAdapter = {
   isValidStream(stream: any): boolean {
     return (
       typeof stream.subscribe === 'function' &&
+      typeof stream.addListener !== 'function' &&
       typeof stream.observe !== 'function' &&
       typeof stream.subscribeOnNext !== 'function' &&
       typeof stream.onValue !== 'function');


### PR DESCRIPTION
<!--
Thank you for your contribution!
To help speed up the process of merging your code, check the following:
-->

- [ ] I added new tests for the issue I fixed/built
- [X] I ran `npm test` for the package I'm modifying
- [X] I used `npm run commit` instead of `git commit`

