### PR TITLE
fix(dom): enable restarting of event streams on isolated components

### DIFF
--- a/dom/package.json
+++ b/dom/package.json
@@ -53,7 +53,7 @@
     "babel-plugin-syntax-jsx": "^6.3.13",
     "babel-plugin-transform-react-jsx": "^6.4.0",
     "rx": "^4.1.0",
-    "rxjs": "^5.0.0-beta.8",
+    "rxjs": "^5.0.0-rc.1",
     "saucie": "^1.4.1",
     "simulant": "^0.2.2",
     "snabbdom-jsx": "^0.3.0",


### PR DESCRIPTION
- [ ] I added new tests for the issue I fixed/built
- [X] I ran `npm test` for the package I'm modifying
- [X] I used `npm run commit` instead of `git commit`

This is a fix for a bug I encountered which is replicated here: http://github.com/ntilwalli/isolateTest

When the DomTest component is isolated I was not able to restart the `itemMouseUp$`

The fix pulls the `hadIsolated_mutable` value out of the closure and into the stream state to ensure that restarted subscriptions cause the `hadIsolated_mutable` value to be reinitialized to `false` (when it wasn't being reinitialized, the remembered DOM was being filtered out for all restarts of the isolated events stream)

__Notes:__ the `isolateTest` uses a local copy of `rxjs-adapter` due to a bug introduced into `rxjs-adapter` a few days ago when `xstream` was updated.  The fix submitted in https://github.com/cyclejs/cyclejs/pull/438 is required and must be installed for that repo to properly replicate this bug.

One test fails which has nothing to do with this fix (it fails even without this update) and shows this output:
```
  1) HTML Driver should output HTMLSource as an adapted stream:

      AssertionError: 'undefined' === 'function'
      + expected - actual

      -undefined
      +function
      
      at Context.<anonymous> (test/node/html-render.js:85:12)
```