### PR TITLE
fix(dom): add virtual DOM sanitation on `dispose()`

### DIFF
--- a/dom/package.json
+++ b/dom/package.json
@@ -14,6 +14,10 @@
     {
       "name": "Tylor Steinberger",
       "email": "tlsteinberger167@gmail.com"
+    },
+    {
+      "name": "Frederik Krautwald",
+      "email": "fkrautwald@gmail.com"
     }
   ],
   "keywords": [

--- a/dom/src/MainDOMSource.ts
+++ b/dom/src/MainDOMSource.ts
@@ -69,6 +69,7 @@ function determineUseCapture(eventType: string, options: EventsFnOptions): boole
 
 export class MainDOMSource implements DOMSource {
   constructor(private _rootElement$: Stream<Element>,
+              private _sanitation$: Stream<{}>,
               private _runStreamAdapter: StreamAdapter,
               private _namespace: Array<string> = [],
               public _isolateModule: IsolateModule,
@@ -116,6 +117,7 @@ export class MainDOMSource implements DOMSource {
       this._namespace.concat(trimmedSelector);
     return new MainDOMSource(
       this._rootElement$,
+      this._sanitation$,
       this._runStreamAdapter,
       childNamespace,
       this._isolateModule,
@@ -204,6 +206,7 @@ export class MainDOMSource implements DOMSource {
   }
 
   dispose(): void {
+    this._sanitation$.shamefullySendNext('');
     this._isolateModule.reset();
   }
 

--- a/dom/src/makeDOMDriver.ts
+++ b/dom/src/makeDOMDriver.ts
@@ -51,7 +51,8 @@ function makeDOMDriver(container: string | Element, options?: DOMDriverOptions):
     const preprocessedVNode$ = (
       transposition ? vnode$.map(transposeVNode).flatten() : vnode$
     );
-    const rootElement$ = preprocessedVNode$
+    const sanitation$ = xs.create();
+    const rootElement$ = xs.merge(preprocessedVNode$.endWhen(sanitation$), sanitation$)
       .map(vnode => vnodeWrapper.call(vnode))
       .fold<VNode>(<(acc: VNode, v: VNode) => VNode>patch, <VNode> rootElement)
       .drop(1)
@@ -63,7 +64,7 @@ function makeDOMDriver(container: string | Element, options?: DOMDriverOptions):
     rootElement$.addListener({next: () => {}, error: () => {}, complete: () => {}});
     /* tslint:enable:no-empty */
 
-    return new MainDOMSource(rootElement$, runStreamAdapter, [], isolateModule, delegators, name);
+    return new MainDOMSource(rootElement$, sanitation$, runStreamAdapter, [], isolateModule, delegators, name);
   };
 
   (<any> DOMDriver).streamAdapter = xsSA;

--- a/dom/test/manual-tests/advanced-list/src/app.js
+++ b/dom/test/manual-tests/advanced-list/src/app.js
@@ -1,7 +1,7 @@
 import xs from 'xstream';
 import {h3, div} from '../../../../lib/index';
 import isolate from '@cycle/isolate';
-import Ticker from './Ticker.js';
+import Ticker from './ticker.js';
 
 function makeRandomColor() {
   let hexColor = Math.floor(Math.random() * 16777215).toString(16);

--- a/dom/test/manual-tests/advanced-list/src/main.js
+++ b/dom/test/manual-tests/advanced-list/src/main.js
@@ -1,6 +1,6 @@
 import {run} from '@cycle/xstream-run';
 import {makeDOMDriver} from '../../../../lib/index';
-import App from './App.js';
+import App from './app.js';
 
 const main = App;
 


### PR DESCRIPTION
- [x] I added new tests for the issue I fixed/built
- [x] I ran `npm test` for the package I'm modifying
- [ ] I used `npm run commit` instead of `git commit`

When `dispose()` was called, the virtual DOM tree wasn’t cleaned properly;
thus, `destroy` hooks on elements (widgets) wouldn’t work and could cause
leaks and side effects.

With this fix, calling `dispose()` destroys the virtual DOM tree that was
created and cleans up all produced effects.

Closes #263