### PR TITLE
fix(META): substitute core-js and es6-shim with --lib options 

### DIFF
--- a/devtool/package.json
+++ b/devtool/package.json
@@ -5,7 +5,7 @@
   "author": "Andre Staltz",
   "license": "MIT",
   "dependencies": {
-    "@cycle/dom": "12.2.x",
+    "@cycle/dom": "12.2.5",
     "@cycle/isolate": "1.4.x",
     "@cycle/xstream-adapter": "3.0.x",
     "circular-json": "^0.3.1",
@@ -15,7 +15,6 @@
   },
   "devDependencies": {
     "@cycle/base": "^4.1.1",
-    "@types/es6-shim": "^0.31.32",
     "@types/webrtc": "0.0.20",
     "browserify": "13.1.0"
   },

--- a/devtool/tsconfig.json
+++ b/devtool/tsconfig.json
@@ -8,7 +8,15 @@
     "suppressImplicitAnyIndexErrors": true,
     "module": "commonjs",
     "target": "ES5",
-    "outDir": "lib/"
+    "outDir": "lib/",
+    "lib": [
+      "dom",
+      "es5",
+      "scripthost",
+      "es2015.collection",
+      "es2015.promise",
+      "es2015.iterable"
+    ]
   },
   "formatCodeOptions": {
     "indentSize": 2,

--- a/dom/package.json
+++ b/dom/package.json
@@ -48,7 +48,6 @@
     "@cycle/isolate": "*",
     "@cycle/rxjs-adapter": "*",
     "@cycle/rxjs-run": "*",
-    "@types/core-js": "^0.9.34",
     "@types/node": "^6.0.45",
     "babel-plugin-jsx-factory": "^1.0.1",
     "babel-plugin-syntax-jsx": "^6.3.13",

--- a/dom/tsconfig.json
+++ b/dom/tsconfig.json
@@ -8,7 +8,15 @@
     "suppressImplicitAnyIndexErrors": true,
     "module": "commonjs",
     "target": "ES5",
-    "outDir": "lib/"
+    "outDir": "lib/",
+    "lib": [
+      "dom",
+      "es5",
+      "scripthost",
+      "es2015.collection",
+      "es2015.promise",
+      "es2015.iterable"
+    ]
   },
   "formatCodeOptions": {
     "indentSize": 2,

--- a/xstream-adapter/package.json
+++ b/xstream-adapter/package.json
@@ -12,8 +12,6 @@
   "dependencies": {},
   "devDependencies": {
     "@cycle/base": "4.x.x",
-    "@types/core-js": "^0.9.34",
-    "es6-promise": "^3.1.2",
     "xstream": "6.x.x"
   },
   "peerDependencies": {

--- a/xstream-adapter/tsconfig.json
+++ b/xstream-adapter/tsconfig.json
@@ -9,7 +9,13 @@
     "module": "commonjs",
     "noEmitHelpers": false,
     "target": "ES5",
-    "outDir": "lib/"
+    "outDir": "lib/",
+    "lib": [
+      "dom",
+      "es5",
+      "scripthost",
+      "es2015.promise"
+    ]
   },
   "formatCodeOptions": {
     "indentSize": 2,


### PR DESCRIPTION
for dom, xstream-adapter, devtool

- [ ] I added new tests for the issue I fixed/built
- [x] I ran `npm test` for the package I'm modifying
- [x] I used `npm run commit` instead of `git commit`

ISSUES CLOSED: #454