### PR TITLE
Update most-run and most-adapter to latest versions of their dependencies

### DIFF
--- a/most-adapter/package.json
+++ b/most-adapter/package.json
@@ -43,14 +43,15 @@
   "bugs": "https://github.com/cyclejs/cyclejs/issues",
   "homepage": "https://cycle.js.org",
   "dependencies": {
-    "@most/create": "^1.1.3",
+    "@most/create": "^2.0.1",
     "@most/hold": "^1.3.1",
-    "most": "^1.0.1",
-    "most-subject": "^4.1.3"
+    "most": "^1.0.5",
+    "most-subject": "^5.0.0"
   },
   "devDependencies": {
     "@cycle/base": "*",
-    "@types/es6-shim": "^0.31.32"
+    "@types/es6-shim": "^0.31.32",
+    "@types/node": "^6.0.46"
   },
   "scripts": {
     "lint": "../node_modules/.bin/tslint -c ../tslint.json src/**/*.ts",

--- a/most-adapter/src/index.ts
+++ b/most-adapter/src/index.ts
@@ -4,12 +4,10 @@ import {
   StreamSubscribe,
   Subject as CycleSubject,
 } from '@cycle/base';
-import {Stream} from 'most';
-import {
-  subject as getMostSubject,
-} from 'most-subject';
+import { Stream } from 'most';
+import { sync } from 'most-subject';
 import hold from '@most/hold';
-import create = require('@most/create');
+import { create } from '@most/create';
 
 const MostAdapter: StreamAdapter = {
   adapt<T>(originStream: any, originStreamSubscribe: StreamSubscribe): Stream<T> {
@@ -28,11 +26,11 @@ const MostAdapter: StreamAdapter = {
   },
 
   remember<T>(stream: Stream<T>): Stream<T> {
-    return stream.thru(hold);
+    return hold(stream);
   },
 
   makeSubject<T>(): CycleSubject<T> {
-    const stream = getMostSubject<any>();
+    const stream = sync<T>();
 
     const observer = {
       next: (x: T) => { stream.next(x); },

--- a/most-adapter/tsconfig.json
+++ b/most-adapter/tsconfig.json
@@ -9,7 +9,14 @@
     "suppressImplicitAnyIndexErrors": true,
     "module": "commonjs",
     "target": "ES5",
-    "outDir": "lib/"
+    "outDir": "lib/",
+    "lib": [
+      "dom",
+      "es2015"
+    ],
+    "types": [
+      "node"
+    ]
   },
   "formatCodeOptions": {
     "indentSize": 2,

--- a/most-run/package.json
+++ b/most-run/package.json
@@ -35,9 +35,9 @@
   "homepage": "https://cycle.js.org",
   "dependencies": {
     "@cycle/base": "4.1.x",
-    "@cycle/most-adapter": "4.0.x",
-    "most": "^1.0.0",
-    "most-subject": "^4.1.1"
+    "@cycle/most-adapter": "4.x.x",
+    "most": "^1.0.5",
+    "most-subject": "^5.0.0"
   },
   "devDependencies": {
     "creed": "^1.0.1"


### PR DESCRIPTION
<!--
Thank you for your contribution!
To help speed up the process of merging your code, check the following:
-->

- [ ] I added new tests for the issue I fixed/built
- [x] I ran `npm test` for the package I'm modifying
- [x] I used `npm run commit` instead of `git commit`

This PR simply updates the dependencies of `most-adapter` to the latest of most, most-subject, and @most/create with minor build changes to fix compilation errors with their improved typings.

Updates the `most-run` dependencies as well to match that of `most-adapter`.