### PR TITLE
fix(dom): skip calling addNS on svg "text" children

### DIFF
--- a/dom/src/hyperscript.ts
+++ b/dom/src/hyperscript.ts
@@ -16,7 +16,8 @@ function addNS(data: any,
                children: Array<VNode | string | Stream<VNode>> | undefined,
                selector: string | undefined): void {
   data.ns = `http://www.w3.org/2000/svg`;
-  if (selector !== `foreignObject` && typeof children !== 'undefined' && is.array(children)) {
+  if (selector !== `text` && selector !== `foreignObject` &&
+        typeof children !== 'undefined' && is.array(children)) {
     for (let i = 0; i < children.length; ++i) {
       if (isGenericStream(children[i])) {
         children[i] = (children[i] as Stream<VNode>).map(mutateStreamWithNS);


### PR DESCRIPTION
- [ ] I added new tests for the issue I fixed/built
- [x] I ran `npm test` for the package I'm modifying
- [x] I used `npm run commit` instead of `git commit`

The addNS errors on svg "text" elements since their children are simple strings which don't have
VNode properties.  This PR skips addNS processing for "text" children.

ISSUES CLOSED: #473