### PR TITLE
fix(http): fix sensitivity to ordering of sinks

### DIFF
--- a/http/src/http-driver.ts
+++ b/http/src/http-driver.ts
@@ -1,4 +1,5 @@
 import xs, {Stream, MemoryStream} from 'xstream';
+import delay from 'xstream/extra/delay';
 import {MainHTTPSource} from './MainHTTPSource';
 import {StreamAdapter, DriverFunction} from '@cycle/base';
 import XStreamAdapter from '@cycle/xstream-adapter';
@@ -154,6 +155,7 @@ export function makeHTTPDriver(): Function {
                       runSA: StreamAdapter,
                       name: string): HTTPSource {
     let response$$ = request$
+      .compose(delay(1))
       .map(makeRequestInputToResponse$(runSA));
     let httpSource = new MainHTTPSource(response$$, runSA, name, []);
     response$$.addListener({next: () => {}, error: () => {}, complete: () => {}});


### PR DESCRIPTION

- [x] I added new tests for the issue I fixed/built
- [x] I ran `npm test` for the package I'm modifying
- [x] I used `npm run commit` instead of `git commit`

The solution here is to simply delay all requests by a little bit, so we never process requests synchronously. This is okay as long as requests are always asynchronous anyway.

ISSUES CLOSED: Closes #476.