### PR TITLE
docs(dom): clarify makeDOMDriver's Snabbdom module override behavior

### DIFF
--- a/dom/README.md
+++ b/dom/README.md
@@ -37,9 +37,9 @@ the element(s) that matches the CSS `selector` given.
 `eventType` happening on the elements that match the current DOMSource. The
 returned stream is an *xstream* Stream if you use `@cycle/xstream-run` to run
 your app with this driver, or it is an RxJS Observable if you use
-`@cycle/rxjs-run`, and so forth. The `options` parameter can have the field
-`useCapture`, which is by default `false`, except it is `true` for event
-types that do not bubble. Read more here
+`@cycle/rxjs-run`, and so forth. The `options` parameter can have the
+property `useCapture`, which is by default `false`, except it is `true` for
+event types that do not bubble. Read more here
 https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
 about the `useCapture` and its purpose.
 
@@ -51,8 +51,11 @@ the app on the DOM.
 #### Arguments:
 
 - `container: String|HTMLElement` the DOM selector for the element (or the element itself) to contain the rendering of the VTrees.
-- `options: DOMDriverOptions` an object with two optional fields: `transposition: boolean` enables/disables transposition of inner streams in
-the virtual DOM tree, `modules: array` contains additional Snabbdom modules.
+- `options: DOMDriverOptions` an object with two optional properties: 
+  - `modules: array` overrides `@cycle/dom`'s default Snabbdom modules as
+    as defined in [`src/modules.ts`](./src/modules.ts).
+  - `transposition: boolean` enables/disables transposition of inner streams
+    in the virtual DOM tree.
 
 #### Return:
 
@@ -101,7 +104,7 @@ sink virtual DOM stream.
 #### Arguments:
 
 - `effect: Function` a callback function that takes a string of rendered HTML as input and should run a side effect, returning nothing.
-- `options: HTMLDriverOptions` an object with one optional field: `transposition: boolean` enables/disables transposition of inner streams in
+- `options: HTMLDriverOptions` an object with one optional property: `transposition: boolean` enables/disables transposition of inner streams in
 the virtual DOM tree.
 
 #### Return:

--- a/dom/src/index.ts
+++ b/dom/src/index.ts
@@ -18,9 +18,9 @@ export {DOMSource, EventsFnOptions} from './DOMSource';
  * `eventType` happening on the elements that match the current DOMSource. The
  * returned stream is an *xstream* Stream if you use `@cycle/xstream-run` to run
  * your app with this driver, or it is an RxJS Observable if you use
- * `@cycle/rxjs-run`, and so forth. The `options` parameter can have the field
- * `useCapture`, which is by default `false`, except it is `true` for event
- * types that do not bubble. Read more here
+ * `@cycle/rxjs-run`, and so forth. The `options` parameter can have the
+ * property `useCapture`, which is by default `false`, except it is `true` for
+ * event types that do not bubble. Read more here
  * https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
  * about the `useCapture` and its purpose.
  *
@@ -31,9 +31,12 @@ export {DOMSource, EventsFnOptions} from './DOMSource';
  *
  * @param {(String|HTMLElement)} container the DOM selector for the element
  * (or the element itself) to contain the rendering of the VTrees.
- * @param {DOMDriverOptions} options an object with two optional fields:
- * `transposition: boolean` enables/disables transposition of inner streams in
- * the virtual DOM tree, `modules: array` contains additional Snabbdom modules.
+ * @param {DOMDriverOptions} options an object with two optional properties:
+ *
+ *   - `modules: array` overrides `@cycle/dom`'s default Snabbdom modules as
+ *     as defined in [`src/modules.ts`](./src/modules.ts).
+ *   - `transposition: boolean` enables/disables transposition of inner streams
+ *     in the virtual DOM tree.
  * @return {Function} the DOM driver function. The function expects a stream of
  * of VNode as input, and outputs the DOMSource object.
  * @function makeDOMDriver
@@ -78,7 +81,7 @@ export {makeDOMDriver, DOMDriverOptions} from './makeDOMDriver';
  *
  * @param {Function} effect a callback function that takes a string of rendered
  * HTML as input and should run a side effect, returning nothing.
- * @param {HTMLDriverOptions} options an object with one optional field:
+ * @param {HTMLDriverOptions} options an object with one optional property:
  * `transposition: boolean` enables/disables transposition of inner streams in
  * the virtual DOM tree.
  * @return {Function} the HTML driver function. The function expects a stream of


### PR DESCRIPTION
<!--
Thank you for your contribution!
To help speed up the process of merging your code, check the following:
-->

- [ ] I added new tests for the issue I fixed/built
- [x] I ran `npm test` for the package I'm modifying
- [x] I used `npm run commit` instead of `git commit`

Clarified that DOMDriverOptions overrides @cycle/dom's default Snabbdom modules, and linked to the TypeScript definition file where those defaults are defined.

Changed wording to "property" instead of "field" in a couple spots.

Issue #471

PR #472

ISSUES CLOSED: #471