### PR TITLE
docs(dom): update README to include ownerTarget

### DIFF
--- a/dom/src/index.ts
+++ b/dom/src/index.ts
@@ -16,6 +16,9 @@ export {DOMSource, EventsFnOptions} from './DOMSource';
  *
  * `DOMSource.events(eventType, options)` returns a stream of events of
  * `eventType` happening on the elements that match the current DOMSource. The
+ * `eventType` contains the `ownerTarget` property that behaves exactly like
+ * `currentTarget`. The reason for this is that some browsers doesn't allow
+ * `currentTarget` property to be mutated, hence a new property is created. The
  * returned stream is an *xstream* Stream if you use `@cycle/xstream-run` to run
  * your app with this driver, or it is an RxJS Observable if you use
  * `@cycle/rxjs-run`, and so forth. The `options` parameter can have the field


### PR DESCRIPTION
<!--
Thank you for your contribution!
To help speed up the process of merging your code, check the following:
-->

The existence of `ownerTarget` is not very obvious to `cycle/dom` users. Hence the README is updated to reflect the existence of it.
