### PR TITLE
fix(dom): change EventDelegator bubble to search topElement instead of body

### DIFF
--- a/dom/src/EventDelegator.ts
+++ b/dom/src/EventDelegator.ts
@@ -74,12 +74,12 @@ export class EventDelegator {
   }
 
   private bubble(rawEvent: Event): void {
-    if (!document.body.contains(rawEvent.currentTarget as Node)) {
+    if (!this.topElement.contains(rawEvent.currentTarget as Node)) {
       return;
     }
     const ev = this.patchEvent(rawEvent);
     for (let el = ev.target as Element; el && el !== this.roof; el = el.parentElement) {
-      if (!document.body.contains(el)) {
+      if (!this.topElement.contains(el)) {
         ev.stopPropagation();
       }
       if (ev.propagationHasBeenStopped) {


### PR DESCRIPTION
- [x] I added new tests for the issue I fixed/built
- [x] I ran `npm test` for the package I'm modifying
- [x] I used `npm run commit` instead of `git commit`

Searching the body will not find the element inside a DocumentFragment or shadowRoot, so the function ends up exiting early and the event is ignored. Added a test for a click inside a DocumentFragment, behaviour is similar to shadowRoot but has better browser support.

ISSUES CLOSED: #412