### PR TITLE
chore(META): exclude .babelrc from NPM builds

### DIFF
--- a/base/.npmignore
+++ b/base/.npmignore
@@ -2,3 +2,4 @@ ignore/
 .idea/
 *.sublime-project
 *.sublime-workspace
+.babelrc

--- a/dom/.npmignore
+++ b/dom/.npmignore
@@ -3,3 +3,4 @@ ignore/
 test/browser/page/tests-bundle.js
 *.sublime-project
 *.sublime-workspace
+.babelrc

--- a/history/.npmignore
+++ b/history/.npmignore
@@ -1,1 +1,2 @@
 src/
+.babelrc

--- a/jsonp/.npmignore
+++ b/jsonp/.npmignore
@@ -2,3 +2,4 @@ ignore/
 .idea/
 *.sublime-project
 *.sublime-workspace
+.babelrc

--- a/most-adapter/.npmignore
+++ b/most-adapter/.npmignore
@@ -2,3 +2,4 @@ ignore/
 .idea/
 *.sublime-project
 *.sublime-workspace
+.babelrc

--- a/most-run/.npmignore
+++ b/most-run/.npmignore
@@ -2,3 +2,4 @@ ignore/
 .idea/
 *.sublime-project
 *.sublime-workspace
+.babelrc

--- a/rx-adapter/.npmignore
+++ b/rx-adapter/.npmignore
@@ -1,2 +1,3 @@
 typings/
 ignore/
+.babelrc

--- a/rx-run/.npmignore
+++ b/rx-run/.npmignore
@@ -2,3 +2,4 @@ ignore/
 .idea/
 *.sublime-project
 *.sublime-workspace
+.babelrc

--- a/rxjs-adapter/.npmignore
+++ b/rxjs-adapter/.npmignore
@@ -1,2 +1,3 @@
 typings/
 ignore/
+.babelrc

--- a/rxjs-run/.npmignore
+++ b/rxjs-run/.npmignore
@@ -2,3 +2,4 @@ ignore/
 .idea/
 *.sublime-project
 *.sublime-workspace
+.babelrc

--- a/xstream-adapter/.npmignore
+++ b/xstream-adapter/.npmignore
@@ -2,3 +2,4 @@ ignore/
 .idea/
 *.sublime-project
 *.sublime-workspace
+.babelrc

--- a/xstream-run/.npmignore
+++ b/xstream-run/.npmignore
@@ -2,3 +2,4 @@ ignore/
 .idea/
 *.sublime-project
 *.sublime-workspace
+.babelrc


### PR DESCRIPTION
<!--
Thank you for your contribution!
To help speed up the process of merging your code, check the following:
-->

- [ ] I added new tests for the issue I fixed/built (n/a)
- [ ] I ran `npm test` for the package I'm modifying (n/a)
- [x] I used `npm run commit` instead of `git commit`

It's not needed anyway. It's also causing issues when used with React-Native packager, which processes node_modules with Babel

(https://github.com/reactjs/redux/issues/1033#issuecomment-156584084)