### PR TITLE
refactor(dom): simplify implementation of mockDOMSource.select() and .events()

### DIFF
--- a/dom/src/mockDOMSource.ts
+++ b/dom/src/mockDOMSource.ts
@@ -28,33 +28,18 @@ export class MockedDOMSource implements DOMSource {
   }
 
   public events(eventType: string, options?: EventsFnOptions): any {
-    const mockConfig = this._mockConfig;
-    const keys = Object.keys(mockConfig);
-    const keysLen = keys.length;
-    for (let i = 0; i < keysLen; i++) {
-      const key = keys[i];
-      if (key === eventType) {
-        const out: DevToolEnabledSource & FantasyObservable = adapt(mockConfig[key] as any);
-        out._isCycleSource = 'MockedDOM';
-        return out;
-      }
-    }
-    const out: DevToolEnabledSource & FantasyObservable = adapt(xs.empty());
+    const streamForEventType = this._mockConfig[eventType] as any;
+    const out: DevToolEnabledSource & FantasyObservable = adapt(streamForEventType || xs.empty());
+
     out._isCycleSource = 'MockedDOM';
+
     return out;
   }
 
   public select(selector: string): MockedDOMSource {
-    const mockConfig = this._mockConfig;
-    const keys = Object.keys(mockConfig);
-    const keysLen = keys.length;
-    for (let i = 0; i < keysLen; i++) {
-      const key = keys[i];
-      if (key === selector) {
-        return new MockedDOMSource(mockConfig[key] as MockConfig);
-      }
-    }
-    return new MockedDOMSource({} as MockConfig);
+    const mockConfigForSelector = this._mockConfig[selector] || {};
+
+    return new MockedDOMSource(mockConfigForSelector as MockConfig);
   }
 
   public isolateSource(source: MockedDOMSource, scope: string): MockedDOMSource {


### PR DESCRIPTION

<!--
Thank you for your contribution!
To help speed up the process of merging your code, check the following:
-->

- [ ] I added new tests for the issue I fixed/built
- [x] I ran `npm test` for the package I'm modifying
- [x] I used `npm run commit` instead of `git commit`

Just happened to be looking at the `mockDOMSource` code and it seemed like it could be improved.

I feel like there's something I've missed and it was done this way originally for a reason.

The tests pass with this change. I haven't benchmarked it, but it should be more performant (`O(1)` instead of `O(n)`).


