### PR TITLE
fix(history): fix history drivers to start emitting the current location

### DIFF
--- a/history/src/createHistory$.ts
+++ b/history/src/createHistory$.ts
@@ -4,7 +4,7 @@ import {HistoryInput} from './types';
 
 export function createHistory$(history: History,
                                sink$: Stream<HistoryInput | string>): MemoryStream<Location> {
-  const history$ = xs.createWithMemory<Location>();
+  const history$ = xs.createWithMemory<Location>().startWith(history.location);
   const call = makeCallOnHistory(history);
   const unlisten = history.listen((loc: Location) => { history$._n(loc); });
   const sub = sink$.subscribe(createObserver(call, unlisten));

--- a/history/test/browser/common.ts
+++ b/history/test/browser/common.ts
@@ -14,6 +14,23 @@ describe('makeHistoryDriver', () => {
   it('should return a function' , () => {
     assert.strictEqual(typeof makeHistoryDriver(), 'function');
   });
+
+  it('should start emitting the current location', function (done) {
+    const history$ = makeHistoryDriver()(xs.never());
+
+    const sub = history$.subscribe({
+      next: (location: Location) => {
+        assert(location.pathname);
+        done();
+      },
+      error: (err) => {},
+      complete: () => {},
+    });
+
+    setTimeout(() => {
+      sub.unsubscribe();
+    });
+  });
 });
 
 describe('makeHashHistoryDriver', () => {
@@ -24,6 +41,23 @@ describe('makeHashHistoryDriver', () => {
   it('should return a function' , () => {
     assert.strictEqual(typeof makeHashHistoryDriver(), 'function');
   });
+
+  it('should start emitting the current location', function (done) {
+    const history$ = makeHashHistoryDriver()(xs.never());
+
+    const sub = history$.subscribe({
+      next: (location: Location) => {
+        assert(location.pathname);
+        done();
+      },
+      error: (err) => {},
+      complete: () => {},
+    });
+
+    setTimeout(() => {
+      sub.unsubscribe();
+    });
+  });
 });
 
 describe('captureClicks', () => {
@@ -31,7 +65,7 @@ describe('captureClicks', () => {
     const historyDriver = makeHistoryDriver();
     const history$ = captureClicks(historyDriver)(xs.never());
 
-    const sub = history$.subscribe({
+    const sub = history$.drop(1).subscribe({
       next: (location: Location) => {
         assert.strictEqual(location.pathname, '/test');
         sub.unsubscribe();

--- a/history/test/browser/rxjs.ts
+++ b/history/test/browser/rxjs.ts
@@ -38,7 +38,7 @@ describe.skip('historyDriver - RxJS', () => {
 
     const {sources, run} = setup(main, { history: makeHistoryDriver() });
 
-    sources.history.subscribe({
+    sources.history.skip(1).subscribe({
       next (location: Location) {
         assert.strictEqual(location.pathname, '/test');
         done();
@@ -58,7 +58,7 @@ describe.skip('historyDriver - RxJS', () => {
 
     const {sources, run} = setup(main, { history: makeHistoryDriver() });
 
-    sources.history.subscribe({
+    sources.history.skip(1).subscribe({
       next (location: Location) {
         assert.strictEqual(location.pathname, '/test');
         done();
@@ -78,7 +78,7 @@ describe.skip('historyDriver - RxJS', () => {
 
     const {sources, run} = setup(main, { history: makeHistoryDriver() });
 
-    sources.history.subscribe({
+    sources.history.skip(1).subscribe({
       next (location: Location) {
         assert.strictEqual(location.pathname, '/test');
         done();
@@ -114,7 +114,7 @@ describe.skip('historyDriver - RxJS', () => {
       '/other',
     ];
 
-    sources.history.subscribe({
+    sources.history.skip(1).subscribe({
       next (location: Location) {
         assert.strictEqual(location.pathname, expected.shift());
         if (expected.length === 0) {

--- a/history/test/browser/xstream.ts
+++ b/history/test/browser/xstream.ts
@@ -37,7 +37,7 @@ describe('historyDriver - xstream', () => {
 
     const {sources, run} = setup(main, { history: makeHistoryDriver() });
 
-    sources.history.subscribe({
+    sources.history.drop(1).subscribe({
       next (location: Location) {
         assert.strictEqual(location.pathname, '/test');
         done();
@@ -57,7 +57,7 @@ describe('historyDriver - xstream', () => {
 
     const {sources, run} = setup(main, { history: makeHistoryDriver() });
 
-    sources.history.subscribe({
+    sources.history.drop(1).subscribe({
       next (location: Location) {
         assert.strictEqual(location.pathname, '/test');
         done();
@@ -77,7 +77,7 @@ describe('historyDriver - xstream', () => {
 
     const {sources, run} = setup(main, { history: makeHistoryDriver() });
 
-    sources.history.subscribe({
+    sources.history.drop(1).subscribe({
       next (location: Location) {
         assert.strictEqual(location.pathname, '/test');
         done();
@@ -113,7 +113,7 @@ describe('historyDriver - xstream', () => {
       '/other',
     ];
 
-    sources.history.subscribe({
+    sources.history.drop(1).subscribe({
       next (location: Location) {
         assert.strictEqual(location.pathname, expected.shift());
         if (expected.length === 0) {

--- a/history/test/node/common.ts
+++ b/history/test/node/common.ts
@@ -1,7 +1,8 @@
 /// <reference path="../../node_modules/@types/mocha/index.d.ts" />
 /// <reference path="../../node_modules/@types/node/index.d.ts" />
 import * as assert from 'assert';
-import {makeServerHistoryDriver} from '../../src';
+import {Location, makeServerHistoryDriver} from '../../src';
+import xs from 'xstream';
 
 describe('makeServerHistoryDriver', () => {
   it('should be a function', () => {
@@ -10,5 +11,22 @@ describe('makeServerHistoryDriver', () => {
 
   it('should return a function' , () => {
     assert.strictEqual(typeof makeServerHistoryDriver(), 'function');
+  });
+
+  it('should start emitting the current location', function (done) {
+    const history$ = makeServerHistoryDriver()(xs.never());
+
+    const sub = history$.subscribe({
+      next: (location: Location) => {
+        assert(location.pathname);
+        done();
+      },
+      error: (err) => {},
+      complete: () => {},
+    });
+
+    setTimeout(() => {
+      sub.unsubscribe();
+    });
   });
 });

--- a/history/test/node/rxjs.ts
+++ b/history/test/node/rxjs.ts
@@ -27,7 +27,7 @@ describe('serverHistoryDriver - RxJS', function () {
 
     const {sources, run} = setup(main, { history: makeServerHistoryDriver() });
 
-    sources.history.subscribe({
+    sources.history.skip(1).subscribe({
       next (location: Location) {
         assert.strictEqual(location.pathname, '/test');
         done();
@@ -47,7 +47,7 @@ describe('serverHistoryDriver - RxJS', function () {
 
     const {sources, run} = setup(main, { history: makeServerHistoryDriver() });
 
-    sources.history.subscribe({
+    sources.history.skip(1).subscribe({
       next (location: Location) {
         assert.strictEqual(location.pathname, '/test');
         done();
@@ -67,7 +67,7 @@ describe('serverHistoryDriver - RxJS', function () {
 
     const {sources, run} = setup(main, { history: makeServerHistoryDriver() });
 
-    sources.history.subscribe({
+    sources.history.skip(1).subscribe({
       next (location: Location) {
         assert.strictEqual(location.pathname, '/test');
         done();
@@ -97,7 +97,7 @@ describe('serverHistoryDriver - RxJS', function () {
       '/test',
     ];
 
-    sources.history.subscribe({
+    sources.history.skip(1).subscribe({
       next (location: Location) {
         assert.strictEqual(location.pathname, expected.shift());
         if (expected.length === 0) {
@@ -129,7 +129,7 @@ describe('serverHistoryDriver - RxJS', function () {
       '/test',
     ];
 
-    sources.history.subscribe({
+    sources.history.skip(1).subscribe({
       next (location: Location) {
         assert.strictEqual(location.pathname, expected.shift());
         if (expected.length === 0) {
@@ -163,7 +163,7 @@ describe('serverHistoryDriver - RxJS', function () {
       '/other',
     ];
 
-    sources.history.subscribe({
+    sources.history.skip(1).subscribe({
       next (location: Location) {
         assert.strictEqual(location.pathname, expected.shift());
         if (expected.length === 0) {
@@ -197,7 +197,7 @@ describe('serverHistoryDriver - RxJS', function () {
       '/other',
     ];
 
-    sources.history.subscribe({
+    sources.history.skip(1).subscribe({
       next (location: Location) {
         assert.strictEqual(location.pathname, expected.shift());
         if (expected.length === 0) {

--- a/history/test/node/xstream.ts
+++ b/history/test/node/xstream.ts
@@ -32,7 +32,7 @@ describe('serverHistoryDriver - xstream', function () {
 
     const {sources, run} = setup(main, { history: makeServerHistoryDriver() });
 
-    sources.history.subscribe({
+    sources.history.drop(1).subscribe({
       next (location: Location) {
         assert.strictEqual(location.pathname, '/test');
         done();
@@ -52,7 +52,7 @@ describe('serverHistoryDriver - xstream', function () {
 
     const {sources, run} = setup(main, { history: makeServerHistoryDriver() });
 
-    sources.history.subscribe({
+    sources.history.drop(1).subscribe({
       next (location: Location) {
         assert.strictEqual(location.pathname, '/test');
         done();
@@ -72,7 +72,7 @@ describe('serverHistoryDriver - xstream', function () {
 
     const {sources, run} = setup(main, { history: makeServerHistoryDriver() });
 
-    sources.history.subscribe({
+    sources.history.drop(1).subscribe({
       next (location: Location) {
         assert.strictEqual(location.pathname, '/test');
         done();
@@ -102,7 +102,7 @@ describe('serverHistoryDriver - xstream', function () {
       '/test',
     ];
 
-    sources.history.subscribe({
+    sources.history.drop(1).subscribe({
       next (location: Location) {
         assert.strictEqual(location.pathname, expected.shift());
         if (expected.length === 0) {
@@ -134,7 +134,7 @@ describe('serverHistoryDriver - xstream', function () {
       '/test',
     ];
 
-    sources.history.subscribe({
+    sources.history.drop(1).subscribe({
       next (location: Location) {
         assert.strictEqual(location.pathname, expected.shift());
         if (expected.length === 0) {
@@ -168,7 +168,7 @@ describe('serverHistoryDriver - xstream', function () {
       '/other',
     ];
 
-    sources.history.subscribe({
+    sources.history.drop(1).subscribe({
       next (location: Location) {
         assert.strictEqual(location.pathname, expected.shift());
         if (expected.length === 0) {
@@ -202,7 +202,7 @@ describe('serverHistoryDriver - xstream', function () {
       '/other',
     ];
 
-    sources.history.subscribe({
+    sources.history.drop(1).subscribe({
       next (location: Location) {
         assert.strictEqual(location.pathname, expected.shift());
         if (expected.length === 0) {


### PR DESCRIPTION
This fixes a bug introduced in d41bdae74904746e0a8983a77305f5bbf3a326c4

- [x] I added new tests for the issue I fixed/built
- [x] I ran `npm test` for the package I'm modifying
- [ ] I used `npm run commit` instead of `git commit`
