### PR TITLE
Use HTTPS for jsonplaceholder endpoints

### DIFF
--- a/docs/basic-examples.html
+++ b/docs/basic-examples.html
@@ -172,7 +172,7 @@ function main(sources) {
   const getRandomUser$ = click$.map(() => {
     const randomNum = Math.round(Math.random() * 9) + 1;
     return {
-      url: 'http://jsonplaceholder.typicode.com/users/' + String(randomNum),
+      url: 'https://jsonplaceholder.typicode.com/users/' + String(randomNum),
       category: 'users',
       method: 'GET'
     };
@@ -263,7 +263,7 @@ function main(sources) {
     .map(() => {
       const randomNum = Math.round(Math.random() * 9) + 1;
       return {
-        url: 'http://jsonplaceholder.typicode.com/users/' + String(randomNum),
+        url: 'https://jsonplaceholder.typicode.com/users/' + String(randomNum),
         category: 'users',
         method: 'GET'
       };

--- a/docs/content/documentation/basic-examples.md
+++ b/docs/content/documentation/basic-examples.md
@@ -144,7 +144,7 @@ function main(sources) {
   const getRandomUser$ = click$.map(() => {
     const randomNum = Math.round(Math.random() * 9) + 1;
     return {
-      url: 'http://jsonplaceholder.typicode.com/users/' + String(randomNum),
+      url: 'https://jsonplaceholder.typicode.com/users/' + String(randomNum),
       category: 'users',
       method: 'GET'
     };
@@ -235,7 +235,7 @@ function main(sources) {
     .map(() => {
       const randomNum = Math.round(Math.random() * 9) + 1;
       return {
-        url: 'http://jsonplaceholder.typicode.com/users/' + String(randomNum),
+        url: 'https://jsonplaceholder.typicode.com/users/' + String(randomNum),
         category: 'users',
         method: 'GET'
       };

--- a/examples/http-random-user/src/index.ts
+++ b/examples/http-random-user/src/index.ts
@@ -32,7 +32,7 @@ function main(sources: {DOM: DOMSource, HTTP: HTTPSource}) {
     .map(() => {
       const randomNum = Math.round(Math.random() * 9) + 1;
       return {
-        url: 'http://jsonplaceholder.typicode.com/users/' + String(randomNum),
+        url: 'https://jsonplaceholder.typicode.com/users/' + String(randomNum),
         category: 'users',
         method: 'GET',
       };


### PR DESCRIPTION
- [x] I used `npm run commit` instead of `git commit`

The [get random user example](https://cycle.js.org/basic-examples.html#basic-examples-http-requests) doesn't seem to be working because https://cycle.js.org/ is served over HTTPS but hitting the HTTP version of jsonplaceholder.typicode.com.

This PR replaces `http://jsonplaceholder.typicode.com` to `https://jsonplaceholder.typicode.com`. Tested in `examples/basic-examples.html` and the HTTPS version works.