### PR TITLE
Correct header for makeServerHistoryDriver documentation

### DIFF
--- a/docs/api/history.html
+++ b/docs/api/history.html
@@ -97,7 +97,7 @@ description on the options.
 
 *(Function)* the History Driver function
 
-## <a id="makeHashHistoryDriver"></a> `makeHashHistoryDriver(options)`
+## <a id="makeServerHistoryDriver"></a> `makeServerHistoryDriver(options)`
 
 Create a History Driver to be used in non-browser enviroments such as
 server-side Node.js.


### PR DESCRIPTION
- Header and anchor for `makeServerHistoryDriver` documentation actually said `makeHashHistoryDriver`