### PR TITLE
feat(history): polymorphic makeHistoryDriver, allow History object for options

### DIFF
--- a/history/src/drivers.ts
+++ b/history/src/drivers.ts
@@ -7,6 +7,8 @@ import {
   MemoryHistoryBuildOptions,
   HashHistoryBuildOptions,
   Location,
+  History,
+  MemoryHistory,
 } from 'history';
 import {createHistory$} from './createHistory$';
 import {
@@ -19,8 +21,16 @@ import {
   ReplaceHistoryInput,
 } from './types';
 
-export function makeHistoryDriver(options?: BrowserHistoryBuildOptions): HistoryDriver {
-  const history = createBrowserHistory(options);
+export function makeHistoryDriver(
+    options?: BrowserHistoryBuildOptions | History | MemoryHistory,
+  ): HistoryDriver {
+  let history: any;
+  if (options && options.hasOwnProperty('createHref')) {
+    history = options;
+  } else {
+    history = createBrowserHistory(options);
+  }
+
   return function historyDriver(sink$: Stream<HistoryInput | string>) {
     return createHistory$(history, sink$);
   };

--- a/history/src/index.ts
+++ b/history/src/index.ts
@@ -1,4 +1,4 @@
-export {Location} from 'history';
+export {Location, History} from 'history';
 export * from './types';
 
 /**
@@ -23,11 +23,13 @@ export {captureClicks} from './captureClicks';
  * (strings representing pathnames or location objects) as input, and outputs
  * another stream of locations that were applied.
  *
- * @param {object} options an object with some options specific to
+ * @param {object|History|MemoryHistory} options an object with some options specific to
  * this driver. These options are the same as for the corresponding
  * `createBrowserHistory()` function in History v4. Check its
  * [docs](https://github.com/mjackson/history/tree/v4.5.1#usage) for a good
- * description on the options.
+ * description on the options. Alternatively, a History object can also be sent
+ * in case the external consumer needs direct access to any of the direct History
+ * methods
  * @return {Function} the History Driver function
  * @function makeHistoryDriver
  */

--- a/history/test/browser/common.ts
+++ b/history/test/browser/common.ts
@@ -3,7 +3,7 @@
 import * as assert from 'assert';
 
 import {Location, captureClicks, makeHashHistoryDriver, makeHistoryDriver} from '../../src';
-
+import {createMemoryHistory} from 'history'
 import xs from 'xstream';
 
 describe('makeHistoryDriver', () => {
@@ -14,6 +14,12 @@ describe('makeHistoryDriver', () => {
   it('should return a function' , () => {
     assert.strictEqual(typeof makeHistoryDriver(), 'function');
   });
+
+  it('should return allow injecting History object directly' , () => {
+    const history = createMemoryHistory()
+    assert.strictEqual(typeof makeHistoryDriver(history), 'function');
+  });
+
 
   it('should start emitting the current location', function (done) {
     const history$ = makeHistoryDriver()(xs.never());

--- a/history/test/node/common.ts
+++ b/history/test/node/common.ts
@@ -1,7 +1,8 @@
 /// <reference path="../../node_modules/@types/mocha/index.d.ts" />
 /// <reference path="../../node_modules/@types/node/index.d.ts" />
 import * as assert from 'assert';
-import {Location, makeServerHistoryDriver} from '../../src';
+import {Location, makeHistoryDriver, makeServerHistoryDriver} from '../../src';
+import {createMemoryHistory} from 'history';
 import xs from 'xstream';
 
 describe('makeServerHistoryDriver', () => {
@@ -11,6 +12,11 @@ describe('makeServerHistoryDriver', () => {
 
   it('should return a function' , () => {
     assert.strictEqual(typeof makeServerHistoryDriver(), 'function');
+  });
+
+  it('should return allow injecting MemoryHistory object directly' , () => {
+    const history = createMemoryHistory()
+    assert.strictEqual(typeof makeHistoryDriver(history), 'function');
   });
 
   it('should start emitting the current location', function (done) {


### PR DESCRIPTION
Allow clients to inject history object directly, useful to libs like cyclic-router which need access
to raw history object's createHref functionality

ISSUES CLOSED: #551

<!--
Thank you for your contribution!
To help speed up the process of merging your code, check the following:
-->

- [ ] I added new tests for the issue I fixed/built
- [x] I ran `npm test` for the package I'm modifying
- [x] I used `npm run commit` instead of `git commit`
