### PR TITLE
docs(search): Add Algolia's DocSearch to allow searching in docs

### DIFF
--- a/docs/.scripts/template.html
+++ b/docs/.scripts/template.html
@@ -12,6 +12,9 @@
   <script src='<%= pathToRoot %>legacy.js'></script>
   <script src='<%= pathToRoot %>flatdoc.js'></script>
 
+  <!-- Algolia's DocSearch main theme -->
+  <link href='//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css' rel='stylesheet' />
+
   <!-- Others -->
   <script async src="//static.jsbin.com/js/embed.js"></script>
 
@@ -67,6 +70,7 @@
         <li><a href='<%= pathToRoot %>api/index.html'>API reference</a></li>
         <li><a href='<%= pathToRoot %>releases.html'>Releases</a></li>
       </ul>
+      <input id="docsearch" />
     </div>
     <div class='right'>
       <!-- GitHub buttons: see https://ghbtns.com -->
@@ -119,5 +123,7 @@
     };
   </script>
   <script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
+  <script src='//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js'></script>
+  <script src='<%= pathToRoot %>docsearch.js'></script>
 </body>
 </html>

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -12,6 +12,9 @@
   <script src='../legacy.js'></script>
   <script src='../flatdoc.js'></script>
 
+  <!-- Algolia's DocSearch main theme -->
+  <link href='//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css' rel='stylesheet' />
+
   <!-- Others -->
   <script async src="//static.jsbin.com/js/embed.js"></script>
 
@@ -63,6 +66,7 @@
         <li><a href='../api/index.html'>API reference</a></li>
         <li><a href='../releases.html'>Releases</a></li>
       </ul>
+      <input id="docsearch" />
     </div>
     <div class='right'>
       <!-- GitHub buttons: see https://ghbtns.com -->
@@ -117,5 +121,7 @@
     };
   </script>
   <script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
+  <script src='//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js'></script>
+  <script src='../docsearch.js'></script>
 </body>
 </html>

--- a/docs/basic-examples.html
+++ b/docs/basic-examples.html
@@ -12,6 +12,9 @@
   <script src='legacy.js'></script>
   <script src='flatdoc.js'></script>
 
+  <!-- Algolia's DocSearch main theme -->
+  <link href='//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css' rel='stylesheet' />
+
   <!-- Others -->
   <script async src="//static.jsbin.com/js/embed.js"></script>
 
@@ -565,6 +568,7 @@ We need a proper architecture for user interfaces that follows the reactive, fun
         <li><a href='api/index.html'>API reference</a></li>
         <li><a href='releases.html'>Releases</a></li>
       </ul>
+      <input id="docsearch" />
     </div>
     <div class='right'>
       <!-- GitHub buttons: see https://ghbtns.com -->
@@ -619,5 +623,7 @@ We need a proper architecture for user interfaces that follows the reactive, fun
     };
   </script>
   <script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
+  <script src='//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js'></script>
+  <script src='docsearch.js'></script>
 </body>
 </html>

--- a/docs/components.html
+++ b/docs/components.html
@@ -12,6 +12,9 @@
   <script src='legacy.js'></script>
   <script src='flatdoc.js'></script>
 
+  <!-- Algolia's DocSearch main theme -->
+  <link href='//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css' rel='stylesheet' />
+
   <!-- Others -->
   <script async src="//static.jsbin.com/js/embed.js"></script>
 
@@ -652,6 +655,7 @@ Each driver should define static functions `isolateSource` and `isolateSink`. We
         <li><a href='api/index.html'>API reference</a></li>
         <li><a href='releases.html'>Releases</a></li>
       </ul>
+      <input id="docsearch" />
     </div>
     <div class='right'>
       <!-- GitHub buttons: see https://ghbtns.com -->
@@ -706,5 +710,7 @@ Each driver should define static functions `isolateSource` and `isolateSink`. We
     };
   </script>
   <script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
+  <script src='//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js'></script>
+  <script src='docsearch.js'></script>
 </body>
 </html>

--- a/docs/dialogue.html
+++ b/docs/dialogue.html
@@ -12,6 +12,9 @@
   <script src='legacy.js'></script>
   <script src='flatdoc.js'></script>
 
+  <!-- Algolia's DocSearch main theme -->
+  <link href='//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css' rel='stylesheet' />
+
   <!-- Others -->
   <script async src="//static.jsbin.com/js/embed.js"></script>
 
@@ -135,6 +138,7 @@ These are questions that drive the core architecture of Cycle.js, but to underst
         <li><a href='api/index.html'>API reference</a></li>
         <li><a href='releases.html'>Releases</a></li>
       </ul>
+      <input id="docsearch" />
     </div>
     <div class='right'>
       <!-- GitHub buttons: see https://ghbtns.com -->
@@ -189,5 +193,7 @@ These are questions that drive the core architecture of Cycle.js, but to underst
     };
   </script>
   <script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
+  <script src='//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js'></script>
+  <script src='docsearch.js'></script>
 </body>
 </html>

--- a/docs/docsearch.js
+++ b/docs/docsearch.js
@@ -1,0 +1,7 @@
+docsearch({
+  apiKey: '9294b142b28d26be38f28f29a5d69b38',
+  indexName: 'cycle_js',
+  inputSelector: '#docsearch',
+  enhancedSearchInput: true,
+  debug: false // Set debug to true if you want to inspect the dropdown
+});

--- a/docs/drivers.html
+++ b/docs/drivers.html
@@ -12,6 +12,9 @@
   <script src='legacy.js'></script>
   <script src='flatdoc.js'></script>
 
+  <!-- Algolia's DocSearch main theme -->
+  <link href='//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css' rel='stylesheet' />
+
   <!-- Others -->
   <script async src="//static.jsbin.com/js/embed.js"></script>
 
@@ -339,6 +342,7 @@ As a framework, it cannot be compared to monoliths which have ruled web developm
         <li><a href='api/index.html'>API reference</a></li>
         <li><a href='releases.html'>Releases</a></li>
       </ul>
+      <input id="docsearch" />
     </div>
     <div class='right'>
       <!-- GitHub buttons: see https://ghbtns.com -->
@@ -389,5 +393,7 @@ As a framework, it cannot be compared to monoliths which have ruled web developm
     };
   </script>
   <script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
+  <script src='//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js'></script>
+  <script src='docsearch.js'></script>
 </body>
 </html>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -12,6 +12,9 @@
   <script src='legacy.js'></script>
   <script src='flatdoc.js'></script>
 
+  <!-- Algolia's DocSearch main theme -->
+  <link href='//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css' rel='stylesheet' />
+
   <!-- Others -->
   <script async src="//static.jsbin.com/js/embed.js"></script>
 
@@ -264,6 +267,7 @@ In the rare occasion you need Cycle.js scripts as standalone JavaScript files, y
         <li><a href='api/index.html'>API reference</a></li>
         <li><a href='releases.html'>Releases</a></li>
       </ul>
+      <input id="docsearch" />
     </div>
     <div class='right'>
       <!-- GitHub buttons: see https://ghbtns.com -->
@@ -314,5 +318,7 @@ In the rare occasion you need Cycle.js scripts as standalone JavaScript files, y
     };
   </script>
   <script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
+  <script src='//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js'></script>
+  <script src='docsearch.js'></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,6 +12,9 @@
   <script src='legacy.js'></script>
   <script src='flatdoc.js'></script>
 
+  <!-- Algolia's DocSearch main theme -->
+  <link href='//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css' rel='stylesheet' />
+
   <!-- Others -->
   <script async src="//static.jsbin.com/js/embed.js"></script>
 
@@ -191,6 +194,7 @@ Got 1 hour and 37 minutes? That is all it takes to learn the essentials of Cycle
         <li><a href='api/index.html'>API reference</a></li>
         <li><a href='releases.html'>Releases</a></li>
       </ul>
+      <input id="docsearch" />
     </div>
     <div class='right'>
       <!-- GitHub buttons: see https://ghbtns.com -->
@@ -231,5 +235,7 @@ Got 1 hour and 37 minutes? That is all it takes to learn the essentials of Cycle
     };
   </script>
   <script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
+  <script src='//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js'></script>
+  <script src='docsearch.js'></script>
 </body>
 </html>

--- a/docs/model-view-intent.html
+++ b/docs/model-view-intent.html
@@ -12,6 +12,9 @@
   <script src='legacy.js'></script>
   <script src='flatdoc.js'></script>
 
+  <!-- Algolia's DocSearch main theme -->
+  <link href='//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css' rel='stylesheet' />
+
   <!-- Others -->
   <script async src="//static.jsbin.com/js/embed.js"></script>
 
@@ -524,6 +527,7 @@ But this still isn't ideal: we seem to have *more* code now. What we really want
         <li><a href='api/index.html'>API reference</a></li>
         <li><a href='releases.html'>Releases</a></li>
       </ul>
+      <input id="docsearch" />
     </div>
     <div class='right'>
       <!-- GitHub buttons: see https://ghbtns.com -->
@@ -578,5 +582,7 @@ But this still isn't ideal: we seem to have *more* code now. What we really want
     };
   </script>
   <script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
+  <script src='//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js'></script>
+  <script src='docsearch.js'></script>
 </body>
 </html>

--- a/docs/releases.html
+++ b/docs/releases.html
@@ -12,6 +12,9 @@
   <script src='legacy.js'></script>
   <script src='flatdoc.js'></script>
 
+  <!-- Algolia's DocSearch main theme -->
+  <link href='//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css' rel='stylesheet' />
+
   <!-- Others -->
   <script async src="//static.jsbin.com/js/embed.js"></script>
 
@@ -992,6 +995,7 @@ For more help, read the [new documentation site Cycle.js.org](http://cycle.js.or
         <li><a href='api/index.html'>API reference</a></li>
         <li><a href='releases.html'>Releases</a></li>
       </ul>
+      <input id="docsearch" />
     </div>
     <div class='right'>
       <!-- GitHub buttons: see https://ghbtns.com -->
@@ -1026,5 +1030,7 @@ For more help, read the [new documentation site Cycle.js.org](http://cycle.js.or
     };
   </script>
   <script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
+  <script src='//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js'></script>
+  <script src='docsearch.js'></script>
 </body>
 </html>

--- a/docs/streams.html
+++ b/docs/streams.html
@@ -12,6 +12,9 @@
   <script src='legacy.js'></script>
   <script src='flatdoc.js'></script>
 
+  <!-- Algolia's DocSearch main theme -->
+  <link href='//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css' rel='stylesheet' />
+
   <!-- Others -->
   <script async src="//static.jsbin.com/js/embed.js"></script>
 
@@ -223,6 +226,7 @@ Next, read the [basic examples](basic-examples.html) which apply what we've lear
         <li><a href='api/index.html'>API reference</a></li>
         <li><a href='releases.html'>Releases</a></li>
       </ul>
+      <input id="docsearch" />
     </div>
     <div class='right'>
       <!-- GitHub buttons: see https://ghbtns.com -->
@@ -277,5 +281,7 @@ Next, read the [basic examples](basic-examples.html) which apply what we've lear
     };
   </script>
   <script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
+  <script src='//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js'></script>
+  <script src='docsearch.js'></script>
 </body>
 </html>

--- a/docs/theme/style.css
+++ b/docs/theme/style.css
@@ -717,6 +717,8 @@ body.no-literate .content pre > code:hover::-webkit-scrollbar-thumb {
 }
 .header .left {
   float: left;
+  display: flex;
+  align-items: center;
 }
 .header .right {
   text-align: right;


### PR DESCRIPTION
Hi @staltz, following your request on the https://community.algolia.com/docsearch/ website, we went further and actually implemented the search input inside Cycle.js docs. I hope you don't mind.

All details have been sent via email too.

**Live demo**: https://docs-uvevkwxznz.now.sh.

Every time you'll select an item for search it redirects to main website, that's expected so you will have to go back to try again.

<details>
  <summary>Demo GIF</summary>

![cyclejs](https://cloud.githubusercontent.com/assets/123822/23996769/fe719946-0a4e-11e7-9757-06b9f1501895.gif)
</details>