### PR TITLE
Use @cycle/time in examples

### DIFF
--- a/examples/animated-letters/package.json
+++ b/examples/animated-letters/package.json
@@ -5,11 +5,12 @@
   "author": "Andre Staltz",
   "license": "MIT",
   "dependencies": {
+    "@cycle/dom": "15.0.0-rc.2",
     "@cycle/isolate": "2.0.0-rc.1",
     "@cycle/run": "1.0.0-rc.8",
-    "@cycle/dom": "15.0.0-rc.2",
-    "xstream": "10.2",
-    "lodash": "4.2.x"
+    "@cycle/time": "^0.8.0",
+    "lodash": "4.2.x",
+    "xstream": "10.2"
   },
   "devDependencies": {
     "babel-plugin-transform-object-rest-spread": "^6.6.5",

--- a/examples/autocomplete-search/package.json
+++ b/examples/autocomplete-search/package.json
@@ -5,11 +5,12 @@
   "author": "Andre Staltz",
   "license": "MIT",
   "dependencies": {
-    "@cycle/run": "1.0.0-rc.8",
     "@cycle/dom": "15.0.0-rc.2",
     "@cycle/jsonp": "7.0.0-rc.1",
-    "xstream": "10.2",
-    "immutable": "^3.7.4"
+    "@cycle/run": "1.0.0-rc.8",
+    "@cycle/time": "^0.8.0",
+    "immutable": "^3.7.4",
+    "xstream": "10.2"
   },
   "devDependencies": {
     "browserify": "13.0.x",

--- a/examples/autocomplete-search/src/app.js
+++ b/examples/autocomplete-search/src/app.js
@@ -91,7 +91,7 @@ function notBetween(first, second) {
   )
 }
 
-function intent(domSource) {
+function intent(domSource, timeSource) {
   const UP_KEYCODE = 38
   const DOWN_KEYCODE = 40
   const ENTER_KEYCODE = 13
@@ -116,7 +116,7 @@ function intent(domSource) {
 
   return {
     search$: input$
-      .compose(debounce(500))
+      .compose(timeSource.debounce(500))
       .compose(between(inputFocus$, inputBlur$))
       .map(ev => ev.target.value)
       .filter(query => query.length > 0),
@@ -291,9 +291,9 @@ function preventedEvents(actions, state$) {
     .filter(ev => ev !== null)
 }
 
-export default function app(responses) {
-  const suggestionsFromResponse$ = networking.processResponses(responses.JSONP)
-  const actions = intent(responses.DOM)
+export default function app(sources) {
+  const suggestionsFromResponse$ = networking.processResponses(sources.JSONP)
+  const actions = intent(sources.DOM, sources.Time)
   const state$ = model(suggestionsFromResponse$, actions)
   const vtree$ = view(state$)
   const prevented$ = preventedEvents(actions, state$)

--- a/examples/autocomplete-search/src/main.js
+++ b/examples/autocomplete-search/src/main.js
@@ -2,7 +2,8 @@ import xs from 'xstream'
 import {run} from '@cycle/run'
 import {makeDOMDriver} from '@cycle/dom'
 import {makeJSONPDriver} from '@cycle/jsonp'
-import app from './app';
+import {timeDriver} from '@cycle/time'
+import app from './app'
 
 function preventDefaultSinkDriver(prevented$) {
   prevented$.addListener({
@@ -23,4 +24,5 @@ run(app, {
   DOM: makeDOMDriver('#main-container'),
   JSONP: makeJSONPDriver(),
   preventDefault: preventDefaultSinkDriver,
+  Time: timeDriver
 });

--- a/examples/custom-driver/package.json
+++ b/examples/custom-driver/package.json
@@ -5,9 +5,10 @@
   "author": "Adam Florczak",
   "license": "MIT",
   "dependencies": {
-    "chart.js": "^2.0.0",
-    "@cycle/run": "1.0.0-rc.8",
     "@cycle/dom": "15.0.0-rc.2",
+    "@cycle/run": "1.0.0-rc.8",
+    "@cycle/time": "^0.8.0",
+    "chart.js": "^2.0.0",
     "xstream": "10.2"
   },
   "devDependencies": {

--- a/examples/custom-driver/src/main.js
+++ b/examples/custom-driver/src/main.js
@@ -1,6 +1,7 @@
 import xs from 'xstream'
 import {run} from '@cycle/run'
 import {makeDOMDriver} from '@cycle/dom'
+import {timeDriver} from '@cycle/time'
 import {makeChartDriver} from './chart-driver'
 
 const timeframeSec = 1
@@ -17,10 +18,10 @@ const chartDefaults = {
   },
 }
 
-function intent(domSource) {
+function intent(domSource, timeSource) {
   return {
     click$: domSource.events('click').mapTo(1),
-    timer$: xs.periodic(timeframeSec * 1000).mapTo(0),
+    timer$: timeSource.periodic(timeframeSec * 1000).mapTo(0),
   }
 }
 
@@ -51,7 +52,7 @@ function view(clicksHistory$) {
 }
 
 function main(sources) {
-  const actions = intent(sources.DOM)
+  const actions = intent(sources.DOM, sources.Time)
   const clicksHistory$ = model(actions)
   const chartData$ = view(clicksHistory$)
 
@@ -63,4 +64,5 @@ function main(sources) {
 run(main, {
   DOM: makeDOMDriver('body'),
   Chart: makeChartDriver('#clicks-chart', chartDefaults),
+  Time: timeDriver
 })

--- a/examples/http-search-github/package.json
+++ b/examples/http-search-github/package.json
@@ -5,9 +5,10 @@
   "author": "Andre Staltz",
   "license": "MIT",
   "dependencies": {
-    "@cycle/run": "1.0.0-rc.8",
     "@cycle/dom": "15.0.0-rc.2",
     "@cycle/http": "12.0.0-rc.1",
+    "@cycle/run": "1.0.0-rc.8",
+    "@cycle/time": "^0.8.0",
     "xstream": "10.2"
   },
   "devDependencies": {

--- a/examples/http-search-github/src/main.js
+++ b/examples/http-search-github/src/main.js
@@ -3,12 +3,13 @@ import debounce from 'xstream/extra/debounce';
 import {run} from '@cycle/run';
 import {div, label, input, hr, ul, li, a, makeDOMDriver} from '@cycle/dom';
 import {makeHTTPDriver} from '@cycle/http';
+import {timeDriver} from '@cycle/time';
 
 function main(sources) {
   // Requests for Github repositories happen when the input field changes,
   // debounced by 500ms, ignoring empty input field.
   const searchRequest$ = sources.DOM.select('.field').events('input')
-    .compose(debounce(500))
+    .compose(sources.Time.debounce(500))
     .map(ev => ev.target.value)
     .filter(query => query.length > 0)
     .map(q => ({
@@ -18,7 +19,7 @@ function main(sources) {
 
   // Requests unrelated to the Github search. This is to demonstrate
   // how filtering for the HTTP response category is necessary.
-  const otherRequest$ = xs.periodic(1000).take(2)
+  const otherRequest$ = sources.Time.periodic(1000).take(2)
     .mapTo({url: 'http://www.google.com', category: 'google'});
 
   // Convert the stream of HTTP responses to virtual DOM elements.
@@ -50,4 +51,5 @@ function main(sources) {
 run(main, {
   DOM: makeDOMDriver('#main-container'),
   HTTP: makeHTTPDriver(),
+  Time: timeDriver
 });

--- a/examples/jsx-seconds-elapsed/package.json
+++ b/examples/jsx-seconds-elapsed/package.json
@@ -5,11 +5,12 @@
   "author": "Andre Staltz",
   "license": "MIT",
   "dependencies": {
+    "@cycle/dom": "15.0.0-rc.2",
     "@cycle/isolate": "2.0.0-rc.1",
     "@cycle/run": "1.0.0-rc.8",
-    "@cycle/dom": "15.0.0-rc.2",
-    "xstream": "10.x.x",
-    "snabbdom-jsx": "0.3.x"
+    "@cycle/time": "^0.8.0",
+    "snabbdom-jsx": "0.3.x",
+    "xstream": "10.x.x"
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.3.13",

--- a/examples/jsx-seconds-elapsed/src/main.js
+++ b/examples/jsx-seconds-elapsed/src/main.js
@@ -1,10 +1,11 @@
 import xs from 'xstream';
 import {run} from '@cycle/run';
 import {makeDOMDriver} from '@cycle/dom';
+import {timeDriver} from '@cycle/time';
 import {html} from 'snabbdom-jsx';
 
 function main(sources) {
-  const vdom$ = xs.periodic(1000).map(i => i + 1).startWith(0)
+  const vdom$ = sources.Time.periodic(1000).map(i => i + 1).startWith(0)
     .map(i =>
       <div>Seconds elapsed {i}</div>
     );
@@ -16,4 +17,5 @@ function main(sources) {
 
 run(main, {
   DOM: makeDOMDriver('#main-container'),
+  Time: timeDriver
 });

--- a/examples/tsx-seconds-elapsed/package.json
+++ b/examples/tsx-seconds-elapsed/package.json
@@ -5,8 +5,9 @@
   "author": "Kay Plößer",
   "license": "MIT",
   "dependencies": {
-    "@cycle/run": "2.0",
     "@cycle/dom": "15.2",
+    "@cycle/run": "2.0",
+    "@cycle/time": "^0.8.0",
     "snabbdom-jsx": "0.3.1",
     "xstream": "10.x"
   },

--- a/examples/tsx-seconds-elapsed/src/index.tsx
+++ b/examples/tsx-seconds-elapsed/src/index.tsx
@@ -1,10 +1,12 @@
 import xs, {Stream} from 'xstream';
 import {run} from '@cycle/run';
 import {makeDOMDriver, DOMSource, VNode} from '@cycle/dom';
+import {timeDriver, TimeSource} from '@cycle/time';
 const {html} = require('snabbdom-jsx');
 
 type Sources = {
   DOM: DOMSource;
+  Time: TimeSource;
 };
 
 type Sinks = {
@@ -12,8 +14,8 @@ type Sinks = {
 };
 
 function main(sources: Sources): Sinks {
-   const vdom$ = xs.periodic(1000).map(i => i + 1).startWith(0)
-     .map(i => <div>Seconds elapsed {i}</div>);
+  const vdom$ = sources.Time.periodic(1000).map(i => i + 1).startWith(0)
+    .map(i => <div>Seconds elapsed {i}</div>);
 
   return {
     DOM: vdom$,
@@ -22,4 +24,5 @@ function main(sources: Sources): Sinks {
 
 run(main, {
   DOM: makeDOMDriver('#main-container'),
+  Time: timeDriver
 });


### PR DESCRIPTION
Closes #575.

I have left the examples that use tween intact, as this is blocked on https://github.com/cyclejs/time/issues/13, which still requires a bit of discussion.

I have made the commits separately for each example I updated so that interested parties could see each one individually, but it might make sense to squash it all together upon merge.

I have manually tested that all examples work the same. 😸 