### PR TITLE
Documentation: Fix typo. Add missing backtick

### DIFF
--- a/docs/api/dom.html
+++ b/docs/api/dom.html
@@ -116,7 +116,7 @@ the sources, for testing.
 
 The `streamAdapter` parameter is a package such as `@cycle/xstream-adapter`,
 `@cycle/rxjs-adapter`, etc. Import it as `import a from '@cycle/rx-adapter`,
-then provide it to `mockDOMSource`. This is important so the DOMSource created
+then provide it to `mockDOMSource. This is important so the DOMSource created
 knows which stream library should it use to export its streams when you call
 `DOMSource.events()` for instance.
 

--- a/docs/api/dom.html
+++ b/docs/api/dom.html
@@ -116,7 +116,7 @@ the sources, for testing.
 
 The `streamAdapter` parameter is a package such as `@cycle/xstream-adapter`,
 `@cycle/rxjs-adapter`, etc. Import it as `import a from '@cycle/rx-adapter`,
-then provide it to `mockDOMSource. This is important so the DOMSource created
+then provide it to `mockDOMSource`. This is important so the DOMSource created
 knows which stream library should it use to export its streams when you call
 `DOMSource.events()` for instance.
 

--- a/dom/src/index.ts
+++ b/dom/src/index.ts
@@ -54,7 +54,7 @@ export {makeDOMDriver, DOMDriverOptions} from './makeDOMDriver';
  *
  * The `streamAdapter` parameter is a package such as `@cycle/xstream-adapter`,
  * `@cycle/rxjs-adapter`, etc. Import it as `import a from '@cycle/rx-adapter`,
- * then provide it to `mockDOMSource. This is important so the DOMSource created
+ * then provide it to `mockDOMSource`. This is important so the DOMSource created
  * knows which stream library should it use to export its streams when you call
  * `DOMSource.events()` for instance.
  *


### PR DESCRIPTION
mockDOMSource missing closing bracket. Has a visible effect - the following sentence is shown in <code>.

<!--
Thank you for your contribution! You're awesome.
To help speed up the process of merging your code, check the following:
-->

- [ ] I added new tests for the issue I fixed/built
- [ ] I ran `yarn test` for the package I'm modifying
- [ ] I used `yarn run commit` instead of `git commit`
