### PR TITLE
Added Streams selection to API docs 

### DIFF
--- a/docs/.scripts/make-api-index.js
+++ b/docs/.scripts/make-api-index.js
@@ -13,6 +13,7 @@ var outputStr = template({
   content: content,
   premenu: [],
   postmenu: [
+    {title: 'Streams', link: 'api/streams.html'},
     {title: 'Cycle Run', link: 'api/run.html'},
     {title: 'Cycle RxJS Run', link: 'api/rxjs-run.html'},
     {title: 'Cycle Most Run', link: 'api/most-run.html'},

--- a/docs/content/api/index.md
+++ b/docs/content/api/index.md
@@ -1,5 +1,6 @@
 # API reference
 
+- **[Streams](streams.html)**
 - **[Cycle Run](run.html)**
 - **[Cycle RxJS Run](rxjs-run.html)**
 - **[Cycle Most Run](most-run.html)**

--- a/docs/content/api/streams.md
+++ b/docs/content/api/streams.md
@@ -1,0 +1,11 @@
+# Streams
+
+Cycle provides an opinionated way of using Reactive Streams but alows a choice of the Stream library used in the `main()` function.
+In addition, a choice of Stream library may be made when implementing drivers. 
+
+`xstream` was created explicity for use with Cycle in common web frontend applications and so is the natural choice.
+However, both `RxJS` and `most` Streams are fully supported in both `main` and drivers. 
+Note that internally, xstream libraries are aways used to interface to the drivers.
+
+The actual Stream library used in `main()` is defined by which stream specific version of the `run()` function is installed and imported. 
+Full details may be found in the API documentation.


### PR DESCRIPTION
I hope this helps. It is not a complete PR though.

- [ ] I added new tests for the issue I fixed/built
- [ ] I ran `yarn test` for the package I'm modifying
- [ ] I used `yarn run commit` instead of `git commit`

I couldn't figure out all the details for these for the docs. Let me know and I'll address them.

Also the other API docs have the JSDocs appended at `#API` which does not apply to this new page. I could not figure out how that is done in order to ensure it was disabled.
