### PR TITLE
docs(basic-examples): use HTTPS endpoint on JSBIN Example

### DIFF
--- a/docs/basic-examples.html
+++ b/docs/basic-examples.html
@@ -157,7 +157,7 @@ One of the most obvious requirements web apps normally have is to fetch and rend
 
 Suppose we have a backend with a database containing ten users. We want to have a front-end with one button "get a random user", and to display the user's details, like name and email. This is what we want to achieve:
 
-<a class="jsbin-embed" href="https://jsbin.com/vedote/embed?output">JS Bin on jsbin.com</a>
+<a class="jsbin-embed" href="https://jsbin.com/basuwahuca/embed?output">JS Bin on jsbin.com</a>
 
 Essentially we just need to make a request for the endpoint `/user/:number` whenever the button is clicked. Where would this HTTP request fit in a Cycle.js app?
 
@@ -300,7 +300,7 @@ run(main, {
 });
 ```
 
-<a class="jsbin-embed" href="https://jsbin.com/vedote/embed?output">JS Bin on jsbin.com</a>
+<a class="jsbin-embed" href="https://jsbin.com/basuwahuca/embed?output">JS Bin on jsbin.com</a>
 
 ## Increment a counter
 


### PR DESCRIPTION
Currently on [CycleJS official docs](https://cycle.js.org/basic-examples.html#basic-examples-http-requests) the JSBin example is not working because of the JSONPlaceHolder URL.

Updated the JSBin example to use https json placeholder url