### PR TITLE
feat(dom): add preventDefault option

### DIFF
--- a/dom/src/BodyDOMSource.ts
+++ b/dom/src/BodyDOMSource.ts
@@ -27,6 +27,12 @@ export class BodyDOMSource implements DOMSource {
     } else {
       stream = fromEvent(document.body, eventType);
     }
+    if (options && options.preventDefault) {
+      stream = stream.map(ev => {
+        ev.preventDefault();
+        return ev;
+      });
+    }
     const out: DevToolEnabledSource & Stream<Event> = adapt(stream);
     out._isCycleSource = this._name;
     return out;

--- a/dom/src/DOMSource.ts
+++ b/dom/src/DOMSource.ts
@@ -1,6 +1,7 @@
 import {Stream, MemoryStream} from 'xstream';
 export interface EventsFnOptions {
   useCapture?: boolean;
+  preventDefault?: boolean;
 }
 
 export interface DOMSource {

--- a/dom/src/DocumentDOMSource.ts
+++ b/dom/src/DocumentDOMSource.ts
@@ -27,6 +27,12 @@ export class DocumentDOMSource implements DOMSource {
     } else {
       stream = fromEvent(document, eventType);
     }
+    if (options && options.preventDefault) {
+      stream = stream.map(ev => {
+        ev.preventDefault();
+        return ev;
+      });
+    }
     const out: DevToolEnabledSource & Stream<Event> = adapt(stream);
     out._isCycleSource = this._name;
     return out;

--- a/dom/src/MainDOMSource.ts
+++ b/dom/src/MainDOMSource.ts
@@ -174,7 +174,7 @@ export class MainDOMSource implements DOMSource {
       rootElement$ = this._rootElement$.take(2);
     }
 
-    const event$: Stream<Event> = rootElement$
+    let event$: Stream<Event> = rootElement$
       .map(function setupEventDelegatorOnTopElement(rootElement) {
         // Event listener just for the root element
         if (!namespace || namespace.length === 0) {
@@ -202,6 +202,13 @@ export class MainDOMSource implements DOMSource {
         return subject;
       })
       .flatten();
+
+    if (options && options.preventDefault) {
+      event$ = event$.map(ev => {
+        ev.preventDefault();
+        return ev;
+      });
+    }
 
     const out: DevToolEnabledSource & Stream<Event> = adapt(event$);
     out._isCycleSource = domSource._name;

--- a/dom/src/index.ts
+++ b/dom/src/index.ts
@@ -26,6 +26,8 @@ export {MainDOMSource} from './MainDOMSource';
  * event types that do not bubble. Read more here
  * https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
  * about the `useCapture` and its purpose.
+ * The other option is `preventDefault` that is set to false by default.
+ * If set to true, the driver will automaticly call `preventDefault()` on every event.
  *
  * `DOMSource.elements()` returns a stream of the DOM element(s) matched by the
  * selectors in the DOMSource. Also, `DOMSource.select(':root').elements()`

--- a/dom/src/index.ts
+++ b/dom/src/index.ts
@@ -27,7 +27,7 @@ export {MainDOMSource} from './MainDOMSource';
  * https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
  * about the `useCapture` and its purpose.
  * The other option is `preventDefault` that is set to false by default.
- * If set to true, the driver will automaticly call `preventDefault()` on every event.
+ * If set to true, the driver will automatically call `preventDefault()` on every event.
  *
  * `DOMSource.elements()` returns a stream of the DOM element(s) matched by the
  * selectors in the DOMSource. Also, `DOMSource.select(':root').elements()`

--- a/dom/test/browser/src/events.ts
+++ b/dom/test/browser/src/events.ts
@@ -839,4 +839,42 @@ describe('DOMSource.events()', function () {
     });
     run();
   });
+
+  it('should prevent default event behavior', function (done) {
+    function app(sources: {DOM: DOMSource}) {
+      return {
+        DOM: xs.of(div('.parent', [
+          form('.form', [
+            input('.field', {type: 'text'}),
+            button('.submit', {type: 'submit'})
+          ]),
+        ])),
+      };
+    }
+
+    const {sinks, sources, run} = setup(app, {
+      DOM: makeDOMDriver(createRenderTarget()),
+    });
+
+    sources.DOM.select('.form').events('submit', { preventDefault: true }).addListener({
+      next: (ev: Event) => {
+        assert.strictEqual(ev.type, 'submit');
+        const target = ev.target as HTMLElement;
+        assert.strictEqual(target.tagName, 'FORM');
+        assert.strictEqual(target.className, 'form');
+        assert.strictEqual(ev.defaultPrevented, true);
+        done();
+      },
+    });
+
+    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+      next: (root: Element) => {
+        const button = root.querySelector('.submit') as HTMLButtonElement;
+        setTimeout(() => button.click());
+      },
+    });
+    run();
+  });
+
+
 });


### PR DESCRIPTION
This would remove impure `preventDefault` calls inside the app. Usage:
```javascript
const event$ = sources.DOM.select('.myform').events('submit', { preventDefault: true });

//currently
const event$ = sources.DOM.select('.myform').events('submit')
    .map(ev => {
        ev.preventDefault();
        return ev;
    });
```

- [x] I added new tests for the issue I fixed/built
- [x] I ran `make test FOO` for the package FOO I'm modifying
- [x] I used `make commit` instead of `git commit`
