### PR TITLE
Exploratory PR for adding pullable's as suggested in issue #581

### DIFF
--- a/run/src/combine-pulls.ts
+++ b/run/src/combine-pulls.ts
@@ -1,0 +1,203 @@
+import xs, {Stream} from 'xstream';
+import {Pullable, PullableValue} from './pullable';
+
+export interface CombineValues {
+  <S, PV1>(s$: Stream<S>,
+    p1: PullableValue<PV1>): Stream<[S, PV1]>;
+  <S, PV1, PV2>(s$: Stream<S>,
+    p1:PullableValue<PV1>, p2:PullableValue<PV2>): Stream<[S, PV1, PV2]>;
+  <S, PV1, PV2, PV3>(s$: Stream<S>,
+    p1:PullableValue<PV1>, p2:PullableValue<PV2>, p3:PullableValue<PV3>):
+    Stream<[S, PV1, PV2, PV3]>;
+  <S, PV1, PV2, PV3, PV4>(s$: Stream<S>,
+    p1:PullableValue<PV1>, p2:PullableValue<PV2>, p3:PullableValue<PV3>,
+    p4:PullableValue<PV4>):
+    Stream<[S, PV1, PV2, PV3, PV4]>;
+  <S, PV1, PV2, PV3, PV4, PV5>(s$: Stream<S>,
+    p1:PullableValue<PV1>, p2:PullableValue<PV2>, p3:PullableValue<PV3>,
+    p4:PullableValue<PV4>, p5:PullableValue<PV5>):
+    Stream<[S, PV1, PV2, PV3, PV4, PV5]>;
+  <S, PV1, PV2, PV3, PV4, PV5, PV6>(s$: Stream<S>,
+    p1:PullableValue<PV1>, p2:PullableValue<PV2>, p3:PullableValue<PV3>,
+    p4:PullableValue<PV4>, p5:PullableValue<PV5>, p6:PullableValue<PV6>):
+    Stream<[S, PV1, PV2, PV3, PV4, PV5, PV6]>;
+  <S, PV1, PV2, PV3, PV4, PV5, PV6, PV7>(s$: Stream<S>,
+    p1:PullableValue<PV1>, p2:PullableValue<PV2>, p3:PullableValue<PV3>,
+    p4:PullableValue<PV4>, p5:PullableValue<PV5>, p6:PullableValue<PV6>,
+    p7:PullableValue<PV7>):
+    Stream<[S, PV1, PV2, PV3, PV4, PV5, PV6, PV7]>;
+  <S, PV1, PV2, PV3, PV4, PV5, PV6, PV7, PV8>(s$: Stream<S>,
+    p1:PullableValue<PV1>, p2:PullableValue<PV2>, p3:PullableValue<PV3>,
+    p4:PullableValue<PV4>, p5:PullableValue<PV5>, p6:PullableValue<PV6>,
+    p7:PullableValue<PV7>, p8:PullableValue<PV8>):
+    Stream<[S, PV1, PV2, PV3, PV4, PV5, PV6, PV7, PV8]>;
+  <S, PV1, PV2, PV3, PV4, PV5, PV6, PV7, PV8, PV9>(s$: Stream<S>,
+    p1:PullableValue<PV1>, p2:PullableValue<PV2>, p3:PullableValue<PV3>,
+    p4:PullableValue<PV4>, p5:PullableValue<PV5>, p6:PullableValue<PV6>,
+    p7:PullableValue<PV7>, p8:PullableValue<PV8>, p9:PullableValue<PV9>):
+    Stream<[S, PV1, PV2, PV3, PV4, PV5, PV6, PV7, PV8, PV9]>;
+  <S, PV1, PV2, PV3, PV4, PV5, PV6, PV7, PV8, PV9, PV10>(s$: Stream<S>,
+    p1:PullableValue<PV1>, p2:PullableValue<PV2>, p3:PullableValue<PV3>,
+    p4:PullableValue<PV4>, p5:PullableValue<PV5>, p6:PullableValue<PV6>,
+    p7:PullableValue<PV7>, p8:PullableValue<PV8>, p9:PullableValue<PV9>,
+    p10:PullableValue<PV10>):
+    Stream<[S, PV1, PV2, PV3, PV4, PV5, PV6, PV7, PV8, PV9, PV10]>;
+}
+
+/**
+ * This function turns stream, given as a first argument, into new stream,
+ * combined with data, pulled from given PullableValue's.
+ * When original stream's event arives, it triggers pulls from given Pullables.
+ * All resulting promises are turned into streams and are combined. Combined
+ * stream is, as usual for xstreams, returns an array of datums. First element
+ * in this array will contain event that originally triggered pulls.
+ * @param {Stream} s$ a stream, which events trigger pulling action
+ * @param {PullableValue} pN are PullableValue's
+ * @return {Stream} is a stream of combined into array values from pulls, with
+ * first element being event that triggered pulling actions.
+ * @function combineValues
+ */
+export const combineValues: CombineValues = (function(
+                      s$: Stream<any>,
+                      ...pvs: PullableValue<any>[]): Stream<any[]> {
+  return s$.map(s => {
+    const streams = pvs
+      .map(pv => pv.pull())
+      .map(promise => xs.fromPromise(promise));
+    return xs.combine(xs.of(s), ...streams);
+  }).flatten();
+}) as any;
+
+export type F<T, U> = (t: T) => U;
+export type PullAndPrep<S, TRequest, TReply> =
+  [ Pullable<TRequest, TReply>, (s: S) => TRequest ];
+
+// XXX extend signature to more entries
+
+export interface CombinePulls {
+  <S, Arg1, P1>(s$:Stream<S>,
+    p1:Pullable<Arg1, P1>, arg1:F<S,Arg1>|null):
+    Stream<[S, P1]>;
+  <S, Arg1, P1, Arg2, P2>(s$:Stream<S>,
+    p1:Pullable<Arg1, P1>, arg1:F<S,Arg1>|null,
+    p2:Pullable<Arg2, P2>, arg2:F<S,Arg2>|null):
+    Stream<[S, P1, P2]>;
+  <S, Arg1, P1, Arg2, P2, Arg3, P3>(s$:Stream<S>,
+    p1:Pullable<Arg1, P1>, arg1:F<S,Arg1>|null,
+    p2:Pullable<Arg2, P2>, arg2:F<S,Arg2>|null,
+    p3:Pullable<Arg3, P3>, arg3:F<S,Arg3>|null):
+    Stream<[S, P1, P2, P3]>;
+  <S, Arg1, P1, Arg2, P2, Arg3, P3, Arg4, P4>(s$:Stream<S>,
+    p1:Pullable<Arg1, P1>, arg1:F<S,Arg1>|null,
+    p2:Pullable<Arg2, P2>, arg2:F<S,Arg2>|null,
+    p3:Pullable<Arg3, P3>, arg3:F<S,Arg3>|null,
+    p4:Pullable<Arg4, P4>, arg4:F<S,Arg4>|null):
+    Stream<[S, P1, P2, P3, P4]>;
+  <S, Arg1, P1, Arg2, P2, Arg3, P3, Arg4, P4, Arg5, P5>(s$:Stream<S>,
+    p1:Pullable<Arg1, P1>, arg1:F<S,Arg1>|null,
+    p2:Pullable<Arg2, P2>, arg2:F<S,Arg2>|null,
+    p3:Pullable<Arg3, P3>, arg3:F<S,Arg3>|null,
+    p4:Pullable<Arg4, P4>, arg4:F<S,Arg4>|null,
+    p5:Pullable<Arg5, P5>, arg5:F<S,Arg5>|null):
+    Stream<[S, P1, P2, P3, P4, P5]>;
+  <S, Arg1, P1, Arg2, P2, Arg3, P3, Arg4, P4, Arg5, P5, Arg6, P6>(s$:Stream<S>,
+    p1:Pullable<Arg1, P1>, arg1:F<S,Arg1>|null,
+    p2:Pullable<Arg2, P2>, arg2:F<S,Arg2>|null,
+    p3:Pullable<Arg3, P3>, arg3:F<S,Arg3>|null,
+    p4:Pullable<Arg4, P4>, arg4:F<S,Arg4>|null,
+    p5:Pullable<Arg5, P5>, arg5:F<S,Arg5>|null,
+    p6:Pullable<Arg6, P6>, arg6:F<S,Arg6>|null):
+    Stream<[S, P1, P2, P3, P4, P5, P6]>;
+  <S, Arg1, P1, Arg2, P2, Arg3, P3, Arg4, P4, Arg5, P5, Arg6, P6, Arg7, P7>(s$:Stream<S>,
+    p1:Pullable<Arg1, P1>, arg1:F<S,Arg1>|null,
+    p2:Pullable<Arg2, P2>, arg2:F<S,Arg2>|null,
+    p3:Pullable<Arg3, P3>, arg3:F<S,Arg3>|null,
+    p4:Pullable<Arg4, P4>, arg4:F<S,Arg4>|null,
+    p5:Pullable<Arg5, P5>, arg5:F<S,Arg5>|null,
+    p6:Pullable<Arg6, P6>, arg6:F<S,Arg6>|null,
+    p7:Pullable<Arg7, P7>, arg7:F<S,Arg7>|null):
+    Stream<[S, P1, P2, P3, P4, P5, P6, P7]>;
+  <S, Arg1, P1, Arg2, P2, Arg3, P3, Arg4, P4, Arg5, P5, Arg6, P6, Arg7, P7>(s$:Stream<S>,
+    p1:Pullable<Arg1, P1>, arg1:F<S,Arg1>|null,
+    p2:Pullable<Arg2, P2>, arg2:F<S,Arg2>|null,
+    p3:Pullable<Arg3, P3>, arg3:F<S,Arg3>|null,
+    p4:Pullable<Arg4, P4>, arg4:F<S,Arg4>|null,
+    p5:Pullable<Arg5, P5>, arg5:F<S,Arg5>|null,
+    p6:Pullable<Arg6, P6>, arg6:F<S,Arg6>|null,
+    p7:Pullable<Arg7, P7>, arg7:F<S,Arg7>|null):
+    Stream<[S, P1, P2, P3, P4, P5, P6, P7]>;
+  <S, Arg1, P1, Arg2, P2, Arg3, P3, Arg4, P4, Arg5, P5, Arg6, P6, Arg7, P7, Arg8, P8>(s$:Stream<S>,
+    p1:Pullable<Arg1, P1>, arg1:F<S,Arg1>|null,
+    p2:Pullable<Arg2, P2>, arg2:F<S,Arg2>|null,
+    p3:Pullable<Arg3, P3>, arg3:F<S,Arg3>|null,
+    p4:Pullable<Arg4, P4>, arg4:F<S,Arg4>|null,
+    p5:Pullable<Arg5, P5>, arg5:F<S,Arg5>|null,
+    p6:Pullable<Arg6, P6>, arg6:F<S,Arg6>|null,
+    p7:Pullable<Arg7, P7>, arg7:F<S,Arg7>|null,
+    p8:Pullable<Arg8, P8>, arg8:F<S,Arg8>|null):
+    Stream<[S, P1, P2, P3, P4, P5, P6, P7, P8]>;
+  <S, Arg1, P1, Arg2, P2, Arg3, P3, Arg4, P4, Arg5, P5, Arg6, P6, Arg7, P7, Arg8, P8, Arg9, P9>(s$:Stream<S>,
+    p1:Pullable<Arg1, P1>, arg1:F<S,Arg1>|null,
+    p2:Pullable<Arg2, P2>, arg2:F<S,Arg2>|null,
+    p3:Pullable<Arg3, P3>, arg3:F<S,Arg3>|null,
+    p4:Pullable<Arg4, P4>, arg4:F<S,Arg4>|null,
+    p5:Pullable<Arg5, P5>, arg5:F<S,Arg5>|null,
+    p6:Pullable<Arg6, P6>, arg6:F<S,Arg6>|null,
+    p7:Pullable<Arg7, P7>, arg7:F<S,Arg7>|null,
+    p8:Pullable<Arg8, P8>, arg8:F<S,Arg8>|null,
+    p9:Pullable<Arg9, P9>, arg9:F<S,Arg9>|null):
+    Stream<[S, P1, P2, P3, P4, P5, P6, P7, P8, P9]>;
+  <S, Arg1, P1, Arg2, P2, Arg3, P3, Arg4, P4, Arg5, P5, Arg6, P6, Arg7, P7, Arg8, P8, Arg9, P9, Arg10, P10>(s$:Stream<S>,
+    p1:Pullable<Arg1, P1>, arg1:F<S,Arg1>|null,
+    p2:Pullable<Arg2, P2>, arg2:F<S,Arg2>|null,
+    p3:Pullable<Arg3, P3>, arg3:F<S,Arg3>|null,
+    p4:Pullable<Arg4, P4>, arg4:F<S,Arg4>|null,
+    p5:Pullable<Arg5, P5>, arg5:F<S,Arg5>|null,
+    p6:Pullable<Arg6, P6>, arg6:F<S,Arg6>|null,
+    p7:Pullable<Arg7, P7>, arg7:F<S,Arg7>|null,
+    p8:Pullable<Arg8, P8>, arg8:F<S,Arg8>|null,
+    p9:Pullable<Arg9, P9>, arg9:F<S,Arg9>|null,
+    p10:Pullable<Arg10, P10>, arg10:F<S,Arg10>|null):
+    Stream<[S, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10]>;
+}
+
+/**
+ * This function turns stream, given as a first argument, into new stream,
+ * combined with data, pulled from given Pullable's or PullableValue's (which,
+ * by the way, extend Pullable interface).
+ * When original stream's event arives, it triggers pulls from given Pullables.
+ * All resulting promises are turned into streams and are combined. Combined
+ * stream is, as usual for xstreams, returns an array of datums. First element
+ * in this array will contain event that originally triggered pulls.
+ * @param {Stream} s$ a stream, which events trigger pulling action
+ * @param {Pullable} pN is either a Pullable or a Pullable value. Pullable
+ * requires that it be followed in arguments list by function that creates pull
+ * request argument. PullableValue, not needing argument for request pull,
+ * should be followed by either null, so as to have one space in arguments list
+ * between Pullable's.
+ * @param {F} argN is either a function that takes stream event and returns an
+ * argument for pull request, or null, if preceding is PullableValue that
+ * doesn't need pull request argument.
+ * @return {Stream} is a stream of combined into array values from pulls, with
+ * first element being event that triggered pulling actions.
+ * @function combinePulls
+ */
+export const combinePulls: CombinePulls = (function(
+                      s$: Stream<any>,
+                      ...pullAndArgFns: (Pullable<any, any>|F<any, any>)[]) {
+  if ((pullAndArgFns.length % 2) !== 0) { throw new Error(
+    "Uneven number of arguments: each pullable must have respective function, or an undefined, for pullable value, but an argument must be present"); }
+  return s$.map(s => {
+    const promises: Promise<any>[] = [];
+    for (let i=0; i<pullAndArgFns.length; i+=1) {
+      const p = pullAndArgFns[i] as Pullable<any, any>;
+      const argFn = pullAndArgFns[i+1] as F<any, any>;
+      promises.push(argFn ?
+        p.pull(argFn(s)) :
+        (p as PullableValue<any>).pull());
+    }
+    const streams = promises
+      .map(promise => xs.fromPromise(promise));
+    return xs.combine(xs.of(s), ...streams);
+  }).flatten();
+}) as any;

--- a/run/src/pullable.ts
+++ b/run/src/pullable.ts
@@ -1,0 +1,285 @@
+import xs, {Stream, Listener, Producer} from 'xstream';
+
+export interface Pullable<TRequest, TReply> {
+  pull(request: TRequest): Promise<TReply>;
+  canProduce(): boolean;
+}
+
+export interface PullableValue<T> extends Pullable<void, T> {
+  pull(): Promise<T>;
+}
+
+export function ConstantValue<T>(c: T): PullableValue<T> {
+  const pull = async () => c;
+  return { pull, canProduce: () => true };
+}
+
+interface DeferredPull<T> {
+  resolve(v: T): void;
+  reject(err?: any): void;
+}
+
+/**
+ * A function that creates pullable value, fed by given stream and an optional
+ * initial value. It can be thought of as a memory cell.
+ * @param {Stream<T>} newValue$ is a stream that feeds new values into created
+ * pullable
+ * @param {T} initValue is an optional initial value. If this argument is not
+ * given, first value will be resolvable upon the first feeding event. If this
+ * argument is given and is undefined, value is considered to be set to
+ * undefined.
+ * @return {Pullable<T>} a pullable value, that is fed by given stream and an
+ * optional initial value.
+ * @function PullableValue
+ */
+export function ChangingValue<T>(
+                            newValue$: Stream<T>,
+                            initValue?: T): PullableValue<T> {
+  let v: T;
+  let isSet = (arguments.length > 1);
+  if (isSet) { v = initValue!; }
+  let deferredPulls: DeferredPull<T>[]|undefined;
+  function canProduce(): boolean {
+    return (isSet || !!deferredPulls);
+  }
+
+  async function pull(): Promise<T> {
+    if (!canProduce()) { throw new Error('Pullable cannot produce values'); }
+    if (isSet) { return v; }
+    return new Promise<T>((resolve, reject) => {
+      if (!deferredPulls) { deferredPulls = []; }
+      deferredPulls.push({resolve, reject});
+    });
+  };
+
+  newValue$.subscribe({
+    next: newValue => {
+      v = newValue;
+      if (isSet) { return; }
+      isSet = true;
+      resolveDeferredPulls();
+    },
+    complete: () => {
+      isSet = false;
+      rejectDeferredPulls(new Error(
+          'Value source completed and detached without giving any value'));
+    },
+    error: err => {
+      isSet = false;
+      rejectDeferredPulls(err);
+    },
+  });
+
+  // resolving of deferreds is done FIFO, each "on the next tick"
+  function resolveDeferredPulls(): void {
+    if (!deferredPulls) { return; }
+    setTimeout(() => {
+      const deferredPull = deferredPulls!.shift();
+      if (deferredPull) {
+        deferredPull.resolve(v);
+        resolveDeferredPulls();
+      }
+      deferredPulls = undefined;
+    }, 0);
+  };
+
+  function rejectDeferredPulls(err: any): void {
+    if (!deferredPulls) { return; }
+    for (const deferredPull of deferredPulls) {
+      deferredPull.reject(err);
+    }
+    deferredPulls = undefined;
+  };
+
+  return { pull, canProduce };
+}
+
+/**
+ * A function that creates pullable backed by some producer circuit.
+ * Consumer's pull is producer's push. This particular pullable pushes
+ * underlying producer in the following manner. Request N+1 is turned into
+ * producer's push only when reply is produced to request N. For a lack of
+ * better name, we call this strategy atomic, hence name it atomic pullable.
+ * @return {object} an object with three fields:
+ * (1) pullable {Pullable<TRequest, TReply>} is a pullable to be backed by some
+ * producer circuit, driven by request stream,
+ * (2) request$ {Stream<TRequest>} is a request stream, with incoming pull
+ * requests, and
+ * (3) replySink {Listener<TReply>} is sink for producer to provide ready
+ * replies.
+ * @function AtomicPullable
+ */
+export function AtomicPullable<T>():
+                      { pullable: PullableValue<T>;
+                        request$: Stream<void>;
+                        replySink: Listener<T>; };
+export function AtomicPullable<TRequest, TReply>():
+                      { pullable: Pullable<TRequest, TReply>;
+                        request$: Stream<TRequest>;
+                        replySink: Listener<TReply>; };
+export function AtomicPullable<TRequest, TReply>():
+                      { pullable: Pullable<TRequest, TReply>;
+                        request$: Stream<TRequest>;
+                        replySink: Listener<TReply>; } {
+  const deferredPulls: {req: TRequest; deferred: DeferredPull<TReply>}[] = [];
+  let pullsListener: Listener<TRequest>|undefined;
+  function canProduce(): boolean {
+    return !!pullsListener;
+  }
+
+  async function pull(req: TRequest): Promise<TReply> {
+    if (!canProduce()) { throw new Error('Pullable cannot produce values'); }
+    const promise = new Promise<TReply>((resolve, reject) => deferredPulls.push(
+      { req, deferred: { resolve, reject } }));
+    if (deferredPulls.length === 1) {
+      pushProducer();
+    }
+    return promise;
+  };
+
+  function pushProducer(): void {
+    if (!pullsListener) { return; }
+    if (deferredPulls.length > 0) {
+      pullsListener.next(deferredPulls[0].req);
+    }
+  };
+
+  const request$ = xs.create<TRequest>({
+    start: listener => { pullsListener = listener; },
+    stop: () => { pullsListener = undefined; },
+  });
+
+  const replySink: Listener<TReply> = {
+    next: rep => {
+      const dp = deferredPulls.shift();
+      if (!dp) {
+        pullsListener = undefined;
+        throw new Error('Got reply when there are no outstanding requests. This is fatal ...');
+      }
+      dp.deferred.resolve(rep);
+      pushProducer();
+    },
+    complete: () => rejectDeferredPulls(new Error(
+      'Value source completed and detached without giving any value')),
+    error: err => rejectDeferredPulls(err),
+  };
+
+  function rejectDeferredPulls(err: any): void {
+    for (const deferredPull of deferredPulls) {
+      deferredPull.deferred.reject(err);
+    }
+    deferredPulls.splice(0, deferredPulls.length);
+    pullsListener = undefined;
+  };
+
+  return { pullable: { pull, canProduce }, request$, replySink };
+}
+
+const MIN_SAFE_INTEGER = ((Number as any).MIN_SAFE_INTEGER ?
+  (Number as any).MIN_SAFE_INTEGER : -Math.pow(2, 52));
+const MAX_SAFE_INTEGER = ((Number as any).MAX_SAFE_INTEGER ?
+  (Number as any).MAX_SAFE_INTEGER : Math.pow(2, 52));
+function nextCount(currentCount: number): number {
+  if (currentCount < MAX_SAFE_INTEGER) { return (currentCount + 1); }
+  return MIN_SAFE_INTEGER;
+}
+
+/**
+ * A function that creates pullable backed by some producer circuit.
+ * Consumer's pull is producer's push. This particular pullable pushes
+ * underlying producer in the following manner. Request is turned into
+ * producer's push as soon as it comes. Replies are guaranteed to come out
+ * orderly, i.e. reply to request N will always resolve before reply to request
+ * N+1. Yet, this particular implementation only checks that producer circuit
+ * sinks replies orderly. If order is broken by producer, this implementation
+ * will throw up and explode as hard as possible and refuse to work afterwards.
+ * Looking from outside, this works like factory conveyor belt, hence, name it
+ * conveyor pullable.
+ * @return {object} an object with three fields:
+ * (1) pullable {Pullable<TRequest, TReply>} is a pullable to be backed by some
+ * producer circuit, driven by request stream,
+ * (2) request$ {Stream<{count: number; req: TRequest;}>} is a stream of pairs,
+ * containing request count number and incoming request itself, and
+ * (3) replySink {Listener<{count: number; rep: TReply;}>} is sink for producer
+ * to provide ready replies and corresponding request counts.
+ * @function AtomicPullable
+ */
+export function ConveyorPullable<T>():
+                      { pullable: PullableValue<T>;
+                        request$: Stream<{count: number; req: void}>;
+                        replySink: Listener<{count: number; rep: T}>; };
+export function ConveyorPullable<TRequest, TReply>():
+                      { pullable: Pullable<TRequest, TReply>;
+                        request$: Stream<{count: number; req: TRequest}>;
+                        replySink: Listener<{count: number; rep: TReply}>; };
+export function ConveyorPullable<TRequest, TReply>():
+                      { pullable: Pullable<TRequest, TReply>;
+                        request$: Stream<{count: number; req: TRequest}>;
+                        replySink: Listener<{count: number; rep: TReply}>; } {
+  const deferredPulls: {count: number; req: TRequest;
+                        deferred: DeferredPull<TReply>}[] = [];
+  let requestCount = MIN_SAFE_INTEGER;
+  let replyCount = requestCount;
+  let pullsListener: Listener<{count: number; req: TRequest}>|undefined;
+  function canProduce(): boolean {
+    return !!pullsListener;
+  }
+
+  async function pull(req: TRequest): Promise<TReply> {
+    if (!canProduce()) { throw new Error('Pullable cannot produce values'); }
+    const promise = new Promise<TReply>((resolve, reject) => {
+      const count = nextCount(requestCount);
+      requestCount = count;
+      deferredPulls.push({ count, req, deferred: { resolve, reject } });
+    });
+    if (deferredPulls.length === 1) {
+      pushProducer();
+    }
+    return promise;
+  };
+
+  function pushProducer(): void {
+    if (!pullsListener) { return; }
+    if (deferredPulls.length > 0) {
+      const {count, req} = deferredPulls[0];
+      pullsListener.next({count, req});
+    }
+  };
+
+  const request$ = xs.create<{count: number; req: TRequest}>({
+    start: listener => { pullsListener = listener; },
+    stop: () => { pullsListener = undefined; },
+  });
+
+  const replySink: Listener<{count: number; rep: TReply}> = {
+    next: countAndReply => {
+      const dp = deferredPulls.shift();
+       if (!dp) {
+         pullsListener = undefined;
+         throw new Error('Got reply when there are no outstanding requests. This is fatal ...');
+      }
+      const {count, rep} = countAndReply;
+      const expectedCount = nextCount(replyCount);
+      if (expectedCount !== count) {
+        rejectDeferredPulls(new Error('Producer messed up order of replies'));
+        return;
+      }
+      dp.deferred.resolve(rep);
+      replyCount = count;
+      pushProducer();
+    },
+    complete: () => rejectDeferredPulls(new Error(
+      'Value source completed and detached without giving any value')),
+    error: err => rejectDeferredPulls(err),
+  };
+
+  function rejectDeferredPulls(err: any): void {
+    for (const deferredPull of deferredPulls) {
+      deferredPull.deferred.reject(err);
+    }
+    deferredPulls.splice(0, deferredPulls.length);
+    pullsListener = undefined;
+  };
+
+  return { pullable: { pull, canProduce }, request$, replySink };
+}


### PR DESCRIPTION
This is an exploratory PR to test idea in issue #581, proving that no major changes needed for bolting on a support for first class (in cycle) objects that carry *pull*-ing.

There are already `PullableValue`'s that can act as memory cells, and a more general `Pullable` that can be used for implementing services that are consumed as *pulls*, while being written in a normal cycle *push* flow, illustrating that consumer's *pull* is producer's *pull*.

- [x] I ran `make test run` for the package `run` I'm modifying. All existing test run, except for lint complaining that new index.ts is 330-something lines, greater than 300 lines.

