### PR TITLE
refactor(dom): preventDefault does not manipulate stream

### DIFF
--- a/dom/src/BodyDOMSource.ts
+++ b/dom/src/BodyDOMSource.ts
@@ -22,17 +22,9 @@ export class BodyDOMSource implements DOMSource {
 
   public events(eventType: string, options: EventsFnOptions = {}): Stream<Event> {
     let stream: Stream<Event>;
-    if (options && typeof options.useCapture === 'boolean') {
-      stream = fromEvent(document.body, eventType, options.useCapture);
-    } else {
-      stream = fromEvent(document.body, eventType);
-    }
-    if (options && options.preventDefault) {
-      stream = stream.map(ev => {
-        ev.preventDefault();
-        return ev;
-      });
-    }
+
+    stream = fromEvent(document.body, eventType, options.useCapture, options.preventDefault);
+
     const out: DevToolEnabledSource & Stream<Event> = adapt(stream);
     out._isCycleSource = this._name;
     return out;

--- a/dom/src/DocumentDOMSource.ts
+++ b/dom/src/DocumentDOMSource.ts
@@ -22,17 +22,9 @@ export class DocumentDOMSource implements DOMSource {
 
   public events(eventType: string, options: EventsFnOptions = {}): Stream<Event> {
     let stream: Stream<Event>;
-    if (options && typeof options.useCapture === 'boolean') {
-      stream = fromEvent(document, eventType, options.useCapture);
-    } else {
-      stream = fromEvent(document, eventType);
-    }
-    if (options && options.preventDefault) {
-      stream = stream.map(ev => {
-        ev.preventDefault();
-        return ev;
-      });
-    }
+
+    stream = fromEvent(document, eventType, options.useCapture, options.preventDefault);
+
     const out: DevToolEnabledSource & Stream<Event> = adapt(stream);
     out._isCycleSource = this._name;
     return out;

--- a/dom/src/EventDelegator.ts
+++ b/dom/src/EventDelegator.ts
@@ -59,11 +59,26 @@ export class EventDelegator {
   constructor(private origin: Element,
               public eventType: string,
               public useCapture: boolean,
-              public isolateModule: IsolateModule) {
-    if (useCapture) {
-      this.listener = (ev: Event) => this.capture(ev);
+              public isolateModule: IsolateModule,
+              public preventDefault = false) {
+    if (preventDefault) {
+      if (useCapture) {
+        this.listener = (ev: Event) => {
+          ev.preventDefault();
+          this.capture(ev);
+        };
+      } else {
+        this.listener = (ev: Event) => {
+          ev.preventDefault();
+          this.bubble(ev);
+        };
+      }
     } else {
-      this.listener = (ev: Event) => this.bubble(ev);
+      if (useCapture) {
+        this.listener = (ev: Event) => this.capture(ev);
+      } else {
+        this.listener = (ev: Event) => this.bubble(ev);
+      }
     }
     origin.addEventListener(eventType, this.listener, useCapture);
   }

--- a/dom/src/MainDOMSource.ts
+++ b/dom/src/MainDOMSource.ts
@@ -174,11 +174,11 @@ export class MainDOMSource implements DOMSource {
       rootElement$ = this._rootElement$.take(2);
     }
 
-    let event$: Stream<Event> = rootElement$
+    const event$: Stream<Event> = rootElement$
       .map(function setupEventDelegatorOnTopElement(rootElement) {
         // Event listener just for the root element
         if (!namespace || namespace.length === 0) {
-          return fromEvent(rootElement, eventType, useCapture);
+          return fromEvent(rootElement, eventType, useCapture, options.preventDefault);
         }
 
         // Event listener on the origin element as an EventDelegator
@@ -190,7 +190,7 @@ export class MainDOMSource implements DOMSource {
           delegator.updateOrigin(origin);
         } else {
           delegator = new EventDelegator(
-            origin, eventType, useCapture, domSource._isolateModule,
+            origin, eventType, useCapture, domSource._isolateModule, options.preventDefault,
           );
           delegators.set(key, delegator);
         }
@@ -202,13 +202,6 @@ export class MainDOMSource implements DOMSource {
         return subject;
       })
       .flatten();
-
-    if (options && options.preventDefault) {
-      event$ = event$.map(ev => {
-        ev.preventDefault();
-        return ev;
-      });
-    }
 
     const out: DevToolEnabledSource & Stream<Event> = adapt(event$);
     out._isCycleSource = domSource._name;

--- a/dom/src/fromEvent.ts
+++ b/dom/src/fromEvent.ts
@@ -2,12 +2,21 @@ import {Stream, Producer, Listener} from 'xstream';
 
 export function fromEvent(element: Element | Document,
                           eventName: string,
-                          useCapture = false): Stream<Event> {
+                          useCapture = false,
+                          preventDefault = false): Stream<Event> {
   return Stream.create<Event>({
     element: element,
     next: null,
     start: function start(listener: Listener<Event>) {
-      this.next = function next(event: Event) { listener.next(event); };
+      if (preventDefault) {
+        this.next = function next(event: Event) {
+          event.preventDefault();
+          listener.next(event);
+        };
+      } else {
+        this.next = function next(event: Event) { listener.next(event); };
+      }
+
       this.element.addEventListener(eventName, this.next, useCapture);
     },
     stop: function stop() {

--- a/dom/test/browser/src/events.ts
+++ b/dom/test/browser/src/events.ts
@@ -840,14 +840,11 @@ describe('DOMSource.events()', function () {
     run();
   });
 
-  it('should prevent default event behavior', function (done) {
+  it('should allow preventing default event behavior', function (done) {
     function app(sources: {DOM: DOMSource}) {
       return {
         DOM: xs.of(div('.parent', [
-          form('.form', [
-            input('.field', {type: 'text'}),
-            button('.submit', {type: 'submit'})
-          ]),
+          button('.button'),
         ])),
       };
     }
@@ -856,12 +853,12 @@ describe('DOMSource.events()', function () {
       DOM: makeDOMDriver(createRenderTarget()),
     });
 
-    sources.DOM.select('.form').events('submit', { preventDefault: true }).addListener({
+    sources.DOM.select('.button').events('click', { preventDefault: true }).addListener({
       next: (ev: Event) => {
-        assert.strictEqual(ev.type, 'submit');
+        assert.strictEqual(ev.type, 'click');
         const target = ev.target as HTMLElement;
-        assert.strictEqual(target.tagName, 'FORM');
-        assert.strictEqual(target.className, 'form');
+        assert.strictEqual(target.tagName, 'BUTTON');
+        assert.strictEqual(target.className, 'button');
         assert.strictEqual(ev.defaultPrevented, true);
         done();
       },
@@ -869,12 +866,11 @@ describe('DOMSource.events()', function () {
 
     sources.DOM.select(':root').elements().drop(1).take(1).addListener({
       next: (root: Element) => {
-        const button = root.querySelector('.submit') as HTMLButtonElement;
+        const button = root.querySelector('.button') as HTMLButtonElement;
         setTimeout(() => button.click());
       },
     });
     run();
   });
-
 
 });


### PR DESCRIPTION
These are most of the changes I was originally going to submit for #65 before #603 beat me to the punch. The main difference is that this does not manipulate the event streams themselves. This also incorporates support for the `preventDefault` option being a function, which was supposedly part of #603 as well before being scrapped for some reason. Not sure these are even still necessary, but who am I to judge?

I suspect some things I did might be slightly bold, so I'd love to hear your opinion.

- [x] I added new tests for the issue I fixed/built
- [x] I ran `make test FOO` for the package FOO I'm modifying
- [x] I used `make commit` instead of `git commit`
