### PR TITLE
feat(time): use setInterval to run events in background

### DIFF
--- a/time/package.json
+++ b/time/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@cycle/run": "3.x",
     "combine-errors": "3.0.x",
+    "performance-now": "^2.1.0",
     "raf": "3.3.x",
     "setimmediate": "1.0.x",
     "sorted-immutable-list": "1.1.x",

--- a/time/src/time-driver.ts
+++ b/time/src/time-driver.ts
@@ -10,7 +10,6 @@ import {runVirtually} from './run-virtually';
 import {TimeSource} from './time-source';
 const requestAnimationFrame = require('raf');
 const now = require('performance-now');
-require('setimmediate');
 
 function popAll(array: Array<any>): Array<any> {
   const poppedItems = [];
@@ -54,7 +53,6 @@ function runRealtime(
 
   function processEvent() {
     if (paused) {
-      setImmediate(processEvent);
       return;
     }
 
@@ -62,8 +60,6 @@ function runRealtime(
     setTime(time);
 
     if (scheduler.isEmpty()) {
-      setImmediate(processEvent);
-
       return;
     }
 
@@ -88,11 +84,9 @@ function runRealtime(
 
       nextEventTime = (scheduler.peek() && scheduler.peek().time) || Infinity;
     }
-
-    setImmediate(processEvent);
   }
 
-  setImmediate(processEvent);
+  setInterval(processEvent, 10);
 
   return {pause, resume};
 }


### PR DESCRIPTION
Previously, all events were driven by requestAnimationFrame. When a tab loses focus, requestAnimationFrame stops executing. By using setImmediate instead, events will fire in the background.

.animationFrames() and .throttleAnimation are still powered by requestAnimationFrame, so will not fire when the tab has lost focus.

Fixes https://github.com/cyclejs/time/issues/37. Progresses #635.
