### PR TITLE
Put svg attributes inside attrs object

### DIFF
--- a/docs/api/dom.html
+++ b/docs/api/dom.html
@@ -98,7 +98,7 @@ the app on the DOM.
 #### Arguments:
 
 - `container: String|HTMLElement` the DOM selector for the element (or the element itself) to contain the rendering of the VTrees.
-- `options: DOMDriverOptions` an object with two optional properties: 
+- `options: DOMDriverOptions` an object with two optional properties:
   - `modules: array` overrides `@cycle/dom`'s default Snabbdom modules as
     as defined in [`src/modules.ts`](./src/modules.ts).
   - `transposition: boolean` enables/disables transposition of inner streams
@@ -181,7 +181,7 @@ SVG element, and `svg.g`, `svg.polygon`, `svg.circle`, `svg.path` are for
 SVG-specific child elements. Example:
 
 ```js
-svg({width: 150, height: 150}, [
+svg({attrs: {width: 150, height: 150}}, [
   svg.polygon({
     attrs: {
       class: 'triangle',

--- a/dom/src/index.ts
+++ b/dom/src/index.ts
@@ -119,7 +119,7 @@ export {CycleDOMEvent} from './EventDelegator';
  * SVG-specific child elements. Example:
  *
  * ```js
- * svg({width: 150, height: 150}, [
+ * svg({attrs: {width: 150, height: 150}}, [
  *   svg.polygon({
  *     attrs: {
  *       class: 'triangle',

--- a/dom/test/browser/src/isolation.ts
+++ b/dom/test/browser/src/isolation.ts
@@ -626,7 +626,7 @@ describe('isolation', function() {
     function App(sources: {DOM: MainDOMSource}) {
       const triangleElement$ = sources.DOM.select('.triangle').elements();
 
-      const svgTriangle = svg({width: 150, height: 150}, [
+      const svgTriangle = svg({attrs: {width: 150, height: 150}}, [
         svg.polygon({
           attrs: {
             class: 'triangle',

--- a/dom/test/browser/src/select.ts
+++ b/dom/test/browser/src/select.ts
@@ -169,7 +169,7 @@ describe('DOMSource.select()', function() {
     function app(sources: {DOM: MainDOMSource}) {
       return {
         DOM: xs.of(
-          svg({width: 150, height: 150}, [
+          svg({attrs: {width: 150, height: 150}}, [
             svg.polygon({
               attrs: {
                 class: 'triangle',


### PR DESCRIPTION
I don't know why the CHANGELOG has been affected by this commit, I just edited the appropriate files and ran `make test dom` & `make commit`

related to https://gitter.im/cyclejs/cyclejs?at=5979ccdac101bc4e3ac5b82b

- [ ] I added new tests for the issue I fixed/built
- [x] I ran `make test FOO` for the package FOO I'm modifying
- [x] I used `make commit` instead of `git commit`
