### PR TITLE
fixed typo in example

### DIFF
--- a/docs/content/documentation/drivers.md
+++ b/docs/content/documentation/drivers.md
@@ -235,7 +235,7 @@ function makeSockDriver(peerId) {
   function sockDriver(outgoing$) {
     outgoing$.addListener({
       next: outgoing => {
-        sock.send(outgoing));
+        sock.send(outgoing);
       },
       error: () => {},
       complete: () => {},


### PR DESCRIPTION
I just fixed a typo and removed one `)`.
