### PR TITLE
refactor(time): enhanced type definitions for MockTimeSource#diagram

### DIFF
--- a/time/src/time-source.ts
+++ b/time/src/time-source.ts
@@ -4,6 +4,10 @@ import {Frame} from './animation-frames';
 export type Operator = <T>(stream: Stream<T>) => Stream<T>;
 export type Comparator = (actual: any, expected: any) => void;
 
+export interface ObjectDictionary<T> {
+  [key: string]: T;
+}
+
 export interface TimeSource {
   animationFrames(): Stream<Frame>;
   delay(delayTime: number): Operator;
@@ -14,6 +18,8 @@ export interface TimeSource {
 }
 
 export interface MockTimeSource extends TimeSource {
+  diagram<T>(str: string, values: ObjectDictionary<T> | Array<T>): Stream<T>;
+  diagram(str: string): Stream<number | string>;
   diagram(str: string, values?: Object): Stream<any>;
   record(stream: Stream<any>): Stream<Array<any>>;
   assertEqual(


### PR DESCRIPTION
diagram method has now three signatures
- the first with one argument, returning `Stream<number | string>`
- the second with two arguments, with the latest an `Array<T>` of values, returning
`Stream<T>`
- the third with two arguments, with the latest an `ObjectDictionary<T>` of values,
returning `Stream<T>`

<!--
Thank you for your contribution! You're awesome.
To help speed up the process of merging your code, check the following:
-->
I didn't add tests since this addition aims to reinforce an existing contract.

- [x] I ran `make test FOO` for the package FOO I'm modifying
- [x] I used `make commit` instead of `git commit`
