### PR TITLE
Switch map polyfill to import statement to make ES6 module build work

### DIFF
--- a/dom/src/IsolateModule.ts
+++ b/dom/src/IsolateModule.ts
@@ -1,6 +1,6 @@
 import {VNode} from 'snabbdom/vnode';
 import {EventDelegator} from './EventDelegator';
-const MapPolyfill: typeof Map = require('es6-map');
+import * as MapPolyfill from 'es6-map';
 
 export class IsolateModule {
   private elementsByFullScope: Map<string, Element>;

--- a/dom/src/makeDOMDriver.ts
+++ b/dom/src/makeDOMDriver.ts
@@ -11,7 +11,7 @@ import {getValidNode} from './utils';
 import defaultModules from './modules';
 import {IsolateModule} from './IsolateModule';
 import {EventDelegator} from './EventDelegator';
-const MapPolyfill: typeof Map = require('es6-map');
+import * as MapPolyfill from 'es6-map';
 
 function makeDOMDriverInputGuard(modules: any) {
   if (!Array.isArray(modules)) {


### PR DESCRIPTION
This is a follow-up to the recent ES6 module build, as per the comment here: https://github.com/cyclejs/cyclejs/pull/662#issuecomment-325375349

The map polyfill was being `require()`d, which was breaking the build when used as ES6 modules. Switched these requires to `import` statements following @jvanbruegge's reply.

<!--
Thank you for your contribution! You're awesome.
To help speed up the process of merging your code, check the following:
-->

- [ ] I added new tests for the issue I fixed/built
- [ ] I ran `make test FOO` for the package FOO I'm modifying
- [x] I used `make commit` instead of `git commit`