### PR TITLE
feat(time): support creating custom operators with Time.createOperator()

### DIFF
--- a/time/most.ts
+++ b/time/most.ts
@@ -5,16 +5,11 @@ import {setAdapt} from '@cycle/run/lib/adapt';
 import {mockTimeSource as mockTimeSourceUntyped} from './src/mock-time-source';
 import {timeDriver as timeDriverUntyped} from './src/time-driver';
 import {Frame} from './src/animation-frames';
-import {Scheduler} from './src/scheduler';
+import {Comparator, OperatorArgs} from './src/types';
 
 setAdapt(stream => most.from(stream as any));
 
 type Operator = <T>(stream: Stream<T>) => Stream<T>;
-export type Comparator = (actual: any, expected: any) => void;
-export type OperatorArgs<T> = {
-  schedule: Scheduler<T>;
-  currentTime(): number;
-};
 
 interface TimeSource {
   animationFrames(): Stream<Frame>;

--- a/time/most.ts
+++ b/time/most.ts
@@ -5,10 +5,16 @@ import {setAdapt} from '@cycle/run/lib/adapt';
 import {mockTimeSource as mockTimeSourceUntyped} from './src/mock-time-source';
 import {timeDriver as timeDriverUntyped} from './src/time-driver';
 import {Frame} from './src/animation-frames';
+import {Scheduler} from './src/scheduler';
 
 setAdapt(stream => most.from(stream as any));
 
 type Operator = <T>(stream: Stream<T>) => Stream<T>;
+export type Comparator = (actual: any, expected: any) => void;
+export type OperatorArgs<T> = {
+  schedule: Scheduler<T>;
+  currentTime(): number;
+};
 
 interface TimeSource {
   animationFrames(): Stream<Frame>;
@@ -20,9 +26,14 @@ interface TimeSource {
 }
 
 interface MockTimeSource extends TimeSource {
+  createOperator<T>(): OperatorArgs<T>;
   diagram(str: string, values?: Object): Stream<any>;
   record(stream: Stream<any>): Stream<Array<any>>;
-  assertEqual(actual: Stream<any>, expected: Stream<any>): void;
+  assertEqual(
+    actual: Stream<any>,
+    expected: Stream<any>,
+    comparator?: Comparator,
+  ): void;
   run(cb?: (err?: Error) => void): void;
 }
 
@@ -34,12 +45,4 @@ function timeDriver(sink: any): TimeSource {
   return timeDriverUntyped(sink);
 }
 
-export {
-  Operator,
-
-  TimeSource,
-  timeDriver,
-
-  MockTimeSource,
-  mockTimeSource
-};
+export {Operator, TimeSource, timeDriver, MockTimeSource, mockTimeSource};

--- a/time/rxjs.ts
+++ b/time/rxjs.ts
@@ -6,12 +6,19 @@ import {setAdapt} from '@cycle/run/lib/adapt';
 import {mockTimeSource as mockTimeSourceUntyped} from './src/mock-time-source';
 import {timeDriver as timeDriverUntyped} from './src/time-driver';
 import {Frame} from './src/animation-frames';
+import {Scheduler} from './src/scheduler';
 
 setAdapt(stream => Observable.from(stream));
 
 type Operator = <T>(observable: Observable<T>) => Observable<T>;
+export type Comparator = (actual: any, expected: any) => void;
+export type OperatorArgs<T> = {
+  schedule: Scheduler<T>;
+  currentTime(): number;
+};
 
 interface TimeSource {
+  createOperator<T>(): OperatorArgs<T>;
   animationFrames(): Observable<Frame>;
   delay(delayTime: number): Operator;
   debounce(period: number): Operator;
@@ -23,7 +30,11 @@ interface TimeSource {
 interface MockTimeSource extends TimeSource {
   diagram(str: string, values?: Object): Observable<any>;
   record(observable: Observable<any>): Observable<Array<any>>;
-  assertEqual(actual: Observable<any>, expected: Observable<any>): void;
+  assertEqual(
+    actual: Observable<any>,
+    expected: Observable<any>,
+    comparator?: Comparator,
+  ): void;
   run(cb?: (err?: Error) => void): void;
 }
 

--- a/time/rxjs.ts
+++ b/time/rxjs.ts
@@ -6,16 +6,11 @@ import {setAdapt} from '@cycle/run/lib/adapt';
 import {mockTimeSource as mockTimeSourceUntyped} from './src/mock-time-source';
 import {timeDriver as timeDriverUntyped} from './src/time-driver';
 import {Frame} from './src/animation-frames';
-import {Scheduler} from './src/scheduler';
+import {Comparator, OperatorArgs} from './src/types';
 
 setAdapt(stream => Observable.from(stream));
 
 type Operator = <T>(observable: Observable<T>) => Observable<T>;
-export type Comparator = (actual: any, expected: any) => void;
-export type OperatorArgs<T> = {
-  schedule: Scheduler<T>;
-  currentTime(): number;
-};
 
 interface TimeSource {
   createOperator<T>(): OperatorArgs<T>;

--- a/time/src/debounce.ts
+++ b/time/src/debounce.ts
@@ -29,7 +29,7 @@ function makeDebounceListener<T>(
     },
 
     complete() {
-      schedule.completion(listener, currentTime());
+      schedule.complete(listener, currentTime());
     },
   };
 }

--- a/time/src/debounce.ts
+++ b/time/src/debounce.ts
@@ -1,5 +1,6 @@
 import xs, {Stream, Listener} from 'xstream';
 import {adapt} from '@cycle/run/lib/adapt';
+import {OperatorArgs} from './types';
 
 function makeDebounceListener<T>(
   schedule: any,
@@ -34,7 +35,9 @@ function makeDebounceListener<T>(
   };
 }
 
-function makeDebounce(schedule: any, currentTime: () => number) {
+function makeDebounce(createOperator: () => OperatorArgs<any>) {
+  const {schedule, currentTime} = createOperator();
+
   return function debounce(debounceInterval: number) {
     return function debounceOperator<T>(stream: Stream<T>): Stream<T> {
       const state = {scheduledEntry: null};

--- a/time/src/delay.ts
+++ b/time/src/delay.ts
@@ -1,5 +1,6 @@
 import xs, {Stream, Listener} from 'xstream';
 import {adapt} from '@cycle/run/lib/adapt';
+import {OperatorArgs} from './types';
 
 function makeDelayListener<T>(
   schedule: any,
@@ -24,7 +25,9 @@ function makeDelayListener<T>(
   };
 }
 
-function makeDelay(schedule: any, currentTime: () => number) {
+function makeDelay(createOperator: () => OperatorArgs<any>) {
+  const {schedule, currentTime} = createOperator();
+
   return function delay(delayTime: number) {
     return function delayOperator<T>(stream: Stream<T>): Stream<T> {
       const producer = {

--- a/time/src/delay.ts
+++ b/time/src/delay.ts
@@ -19,7 +19,7 @@ function makeDelayListener<T>(
     },
 
     complete() {
-      schedule.completion(listener, delayedTime());
+      schedule.complete(listener, delayedTime());
     },
   };
 }

--- a/time/src/diagram.ts
+++ b/time/src/diagram.ts
@@ -50,7 +50,7 @@ function makeDiagram(
       }
 
       if (character === '|') {
-        schedule.completion(stream, timeToSchedule);
+        schedule.complete(stream, timeToSchedule);
       } else if (character === '#') {
         schedule.error(stream, timeToSchedule, new Error(`scheduled error`));
       } else {

--- a/time/src/mock-time-source.ts
+++ b/time/src/mock-time-source.ts
@@ -68,6 +68,10 @@ function mockTimeSource({interval = 20} = {}): any {
     maxTime = Math.max(newTime, maxTime);
   }
 
+  function createOperator() {
+    return {schedule: scheduler.add, currentTime};
+  }
+
   const timeSource = {
     diagram: makeDiagram(scheduler.add, currentTime, interval, setMaxTime),
     record: makeRecord(scheduler.add, currentTime, interval),
@@ -79,10 +83,10 @@ function mockTimeSource({interval = 20} = {}): any {
       addAssert,
     ),
 
-    delay: makeDelay(scheduler.add, currentTime),
-    debounce: makeDebounce(scheduler.add, currentTime),
-    periodic: makePeriodic(scheduler.add, currentTime),
-    throttle: makeThrottle(scheduler.add, currentTime),
+    delay: makeDelay(createOperator),
+    debounce: makeDebounce(createOperator),
+    periodic: makePeriodic(createOperator),
+    throttle: makeThrottle(createOperator),
 
     animationFrames: () => timeSource.periodic(16).map(frame),
     throttleAnimation: makeThrottleAnimation(
@@ -105,10 +109,10 @@ function mockTimeSource({interval = 20} = {}): any {
       );
     },
 
+    createOperator,
+
     _scheduler: scheduler.add,
     _time: currentTime,
-
-    createOperator: () => ({schedule: scheduler.add, currentTime}),
   };
 
   return timeSource;

--- a/time/src/mock-time-source.ts
+++ b/time/src/mock-time-source.ts
@@ -107,6 +107,8 @@ function mockTimeSource({interval = 20} = {}): any {
 
     _scheduler: scheduler.add,
     _time: currentTime,
+
+    createOperator: () => ({schedule: scheduler.add, currentTime}),
   };
 
   return timeSource;

--- a/time/src/periodic.ts
+++ b/time/src/periodic.ts
@@ -43,7 +43,7 @@ function makePeriodic(schedule: any, currentTime: () => number) {
 
       stop() {
         stopped = true;
-        schedule.completion(producer.listener, currentTime());
+        schedule.complete(producer.listener, currentTime());
       },
     };
 

--- a/time/src/periodic.ts
+++ b/time/src/periodic.ts
@@ -1,7 +1,10 @@
 import xs, {Stream, Listener} from 'xstream';
 import {adapt} from '@cycle/run/lib/adapt';
+import {OperatorArgs} from './types';
 
-function makePeriodic(schedule: any, currentTime: () => number) {
+function makePeriodic(createOperator: () => OperatorArgs<any>) {
+  const {schedule, currentTime} = createOperator();
+
   return function periodic(period: number): Stream<number> {
     let stopped = false;
     let lastEmitTime = 0;
@@ -29,7 +32,7 @@ function makePeriodic(schedule: any, currentTime: () => number) {
     }
 
     const producer = {
-      listener: null as (Listener<any> | null),
+      listener: null as Listener<any> | null,
 
       start(listener: Listener<any>) {
         producer.listener = listener;
@@ -43,7 +46,7 @@ function makePeriodic(schedule: any, currentTime: () => number) {
 
       stop() {
         stopped = true;
-        schedule.complete(producer.listener, currentTime());
+        schedule.complete(producer.listener as Listener<any>, currentTime());
       },
     };
 

--- a/time/src/scheduler.ts
+++ b/time/src/scheduler.ts
@@ -1,4 +1,20 @@
+import {Listener} from 'xstream';
 const makeAccumulator = require('sorted-immutable-list').default;
+
+export interface Schedule<T> {
+  shiftNextEntry(): T | undefined;
+  isEmpty(): boolean;
+  peek(): T | undefined;
+  add: Scheduler<T>;
+}
+
+export interface Scheduler<T> {
+  _schedule: any;
+
+  next(listener: Listener<T>, time: number, value: T): void;
+  error(listener: Listener<T>, time: number, error: Error): void;
+  complete(listener: Listener<T>, time: number): void;
+}
 
 const comparator = (a: any) => (b: any) => {
   if (a.time < b.time) {
@@ -23,7 +39,7 @@ const comparator = (a: any) => (b: any) => {
   return 1;
 };
 
-function makeScheduler() {
+function makeScheduler<T>(): Schedule<T> {
   let schedule: Array<any> = [];
 
   function getSchedule() {
@@ -78,7 +94,7 @@ function makeScheduler() {
         });
       },
 
-      completion(stream: any, time: number) {
+      complete(stream: any, time: number) {
         return scheduleEntry({
           type: 'complete',
           stream,

--- a/time/src/scheduler.ts
+++ b/time/src/scheduler.ts
@@ -8,10 +8,22 @@ export interface Schedule<T> {
   add: Scheduler<T>;
 }
 
+export type PostEventCallback<T> = (
+  event: any,
+  time: number,
+  schedule: Scheduler<T>,
+  currentTime: () => number,
+) => void;
+
 export interface Scheduler<T> {
   _schedule: any;
 
-  next(listener: Listener<T>, time: number, value: T): void;
+  next(
+    listener: Listener<T>,
+    time: number,
+    value: T,
+    callback?: PostEventCallback<T>,
+  ): void;
   error(listener: Listener<T>, time: number, error: Error): void;
   complete(listener: Listener<T>, time: number): void;
 }

--- a/time/src/throttle-animation.ts
+++ b/time/src/throttle-animation.ts
@@ -37,7 +37,7 @@ function makeThrottleAnimation(
 
           complete() {
             frame$.removeListener(animationListener);
-            schedule.completion(listener, currentTime());
+            schedule.complete(listener, currentTime());
           },
         });
 

--- a/time/src/throttle.ts
+++ b/time/src/throttle.ts
@@ -1,5 +1,6 @@
 import xs, {Stream, Listener} from 'xstream';
 import {adapt} from '@cycle/run/lib/adapt';
+import {OperatorArgs} from './types';
 
 function makeThrottleListener<T>(
   schedule: any,
@@ -35,7 +36,9 @@ function makeThrottleListener<T>(
   };
 }
 
-function makeThrottle(schedule: any, currentTime: () => number) {
+function makeThrottle(createOperator: () => OperatorArgs<any>) {
+  const {schedule, currentTime} = createOperator();
+
   return function throttle(period: number) {
     return function throttleOperator<T>(stream: Stream<T>): Stream<T> {
       const state = {lastEventTime: -Infinity}; // so that the first event is always scheduled

--- a/time/src/throttle.ts
+++ b/time/src/throttle.ts
@@ -30,7 +30,7 @@ function makeThrottleListener<T>(
     },
 
     complete() {
-      schedule.completion(listener, currentTime());
+      schedule.complete(listener, currentTime());
     },
   };
 }

--- a/time/src/time-driver.ts
+++ b/time/src/time-driver.ts
@@ -135,6 +135,8 @@ function timeDriver(sink: any): any {
       // TODO - frameCallbacks?
       runVirtually(scheduler, done, currentTime, setTime, timeToRunTo);
     },
+
+    createOperator: () => ({schedule: scheduler.add, currentTime}),
   };
 
   return timeSource;

--- a/time/src/time-driver.ts
+++ b/time/src/time-driver.ts
@@ -116,12 +116,16 @@ function timeDriver(sink: any): any {
     setTime,
   );
 
+  function createOperator() {
+    return {schedule: scheduler.add, currentTime};
+  }
+
   const timeSource = {
     animationFrames: makeAnimationFrames(addFrameCallback, currentTime),
-    delay: makeDelay(scheduler.add, currentTime),
-    debounce: makeDebounce(scheduler.add, currentTime),
-    periodic: makePeriodic(scheduler.add, currentTime),
-    throttle: makeThrottle(scheduler.add, currentTime),
+    delay: makeDelay(createOperator),
+    debounce: makeDebounce(createOperator),
+    periodic: makePeriodic(createOperator),
+    throttle: makeThrottle(createOperator),
     throttleAnimation: makeThrottleAnimation(
       () => timeSource,
       scheduler.add,
@@ -136,7 +140,7 @@ function timeDriver(sink: any): any {
       runVirtually(scheduler, done, currentTime, setTime, timeToRunTo);
     },
 
-    createOperator: () => ({schedule: scheduler.add, currentTime}),
+    createOperator,
   };
 
   return timeSource;

--- a/time/src/time-source.ts
+++ b/time/src/time-source.ts
@@ -1,13 +1,8 @@
 import {Stream} from 'xstream';
 import {Frame} from './animation-frames';
-import {Scheduler} from './scheduler';
+import {Comparator, OperatorArgs} from './types';
 
 export type Operator = <T>(stream: Stream<T>) => Stream<T>;
-export type Comparator = (actual: any, expected: any) => void;
-export type OperatorArgs<T> = {
-  schedule: Scheduler<T>;
-  currentTime(): number;
-};
 
 export interface TimeSource {
   createOperator<T>(): OperatorArgs<T>;

--- a/time/src/time-source.ts
+++ b/time/src/time-source.ts
@@ -1,10 +1,16 @@
 import {Stream} from 'xstream';
 import {Frame} from './animation-frames';
+import {Scheduler} from './scheduler';
 
 export type Operator = <T>(stream: Stream<T>) => Stream<T>;
 export type Comparator = (actual: any, expected: any) => void;
+export type OperatorArgs<T> = {
+  schedule: Scheduler<T>;
+  currentTime(): number;
+};
 
 export interface TimeSource {
+  createOperator<T>(): OperatorArgs<T>;
   animationFrames(): Stream<Frame>;
   delay(delayTime: number): Operator;
   debounce(period: number): Operator;

--- a/time/src/types.ts
+++ b/time/src/types.ts
@@ -1,0 +1,8 @@
+import {Scheduler} from './scheduler';
+
+export type Comparator = (actual: any, expected: any) => void | boolean;
+
+export type OperatorArgs<T> = {
+  schedule: Scheduler<T>;
+  currentTime(): number;
+};

--- a/time/test/time.ts
+++ b/time/test/time.ts
@@ -37,9 +37,13 @@ describe('@cycle/time', () => {
 
   it('can be used to test Cycle apps', done => {
     function Counter({DOM}: any) {
-      const add$ = DOM.select('.add').events('click').mapTo(+1);
+      const add$ = DOM.select('.add')
+        .events('click')
+        .mapTo(+1);
 
-      const subtract$ = DOM.select('.subtract').events('click').mapTo(-1);
+      const subtract$ = DOM.select('.subtract')
+        .events('click')
+        .mapTo(-1);
 
       const change$ = xs.merge(add$, subtract$);
 


### PR DESCRIPTION
Also, rename scheduler.completion to scheduler.complete for consistency
with xstream addListener names.

Closes https://github.com/cyclejs/time/issues/31