### PR TITLE
fix(http): allow string type for send property

### DIFF
--- a/http/src/index.ts
+++ b/http/src/index.ts
@@ -18,7 +18,7 @@
  * the HTTP Source when querying for the response. E.g.
  * `sources.http.select(category)`
  * - `query` *(Object)*: an object with the payload for `GET` or `POST`.
- * - `send` *(Object)*: an object with the payload for `POST`.
+ * - `send` *(Object|String)*: an object or string with the payload for `POST`.
  * - `headers` *(Object)*: object specifying HTTP headers.
  * - `accept` *(String)*: the Accept header.
  * - `type` *(String)*: a short-hand for setting Content-Type.

--- a/http/src/interfaces.ts
+++ b/http/src/interfaces.ts
@@ -16,7 +16,7 @@ export interface RequestOptions {
   url: string;
   method?: string;
   query?: Object;
-  send?: Object;
+  send?: Object | string;
   headers?: Object;
   accept?: string;
   type?: string;

--- a/http/test/browser/src/common.ts
+++ b/http/test/browser/src/common.ts
@@ -160,6 +160,35 @@ export function run(uri: string) {
       run();
     });
 
+    it('should return response metastream when send with type string [#674]', function(
+      done,
+    ) {
+      function main(sources: {HTTP: HTTPSource}) {
+        return {
+          HTTP: Rx.Observable.of({
+            url: uri + '/pet',
+            method: 'POST',
+            send: 'name=Woof&species=Dog',
+          }),
+        };
+      }
+
+      const {sources, run} = Cycle.setup(main, {HTTP: makeHTTPDriver()});
+
+      const response$$ = sources.HTTP.select();
+      response$$.subscribe(function(response$) {
+        assert.strictEqual(response$.request.url, uri + '/pet');
+        assert.strictEqual(response$.request.method, 'POST');
+        assert.strictEqual((response$.request.send as string), 'name=Woof&species=Dog');
+        response$.subscribe(function(response) {
+          assert.strictEqual(response.status, 200);
+          assert.strictEqual(response.text, 'added Woof the Dog');
+          done();
+        });
+      });
+      run();
+    });
+
     it('should have DevTools flag in select() source stream', function(done) {
       function main(sources: {HTTP: HTTPSource}) {
         return {


### PR DESCRIPTION
> By default sending strings will set the `Content-Type` to `application/x-www-form-urlencoded`.

Example from the document of superagent:

```js
  request.post('/user')
    // object
    .send({ name: 'tj' })
    // or string
    .send('name=tj')
    ...
```

Ref: http://visionmedia.github.io/superagent/

<!--
Thank you for your contribution! You're awesome.
To help speed up the process of merging your code, check the following:
-->

- [x] I added new tests for the issue I fixed/built
- [x] I ran `make test FOO` for the package FOO I'm modifying
- [x] I used `make commit` instead of `git commit`
