### PR TITLE
feat(dom): overload .event() method using HTMLElementEventMap

### DIFF
--- a/dom/src/DOMSource.ts
+++ b/dom/src/DOMSource.ts
@@ -8,5 +8,9 @@ export interface EventsFnOptions {
 export interface DOMSource {
   select(selector: string): DOMSource;
   elements(): MemoryStream<Document | Element | Array<Element> | string>;
+  events<K extends keyof HTMLElementEventMap>(
+    eventType: K,
+    options?: EventsFnOptions,
+  ): Stream<HTMLElementEventMap[K]>;
   events(eventType: string, options?: EventsFnOptions): Stream<Event>;
 }


### PR DESCRIPTION
The lib.dom.d.ts file contains a mapping where the name of the event type is mapped to the event
type itself (e.g. click -> MouseEvent). Using this mapping on the DOMSource.events() function allows
the correct event stream to be returned.

<!--
Thank you for your contribution! You're awesome.
To help speed up the process of merging your code, check the following:
-->

- [ ] I added new tests for the issue I fixed/built
- [x] I ran `make test FOO` for the package FOO I'm modifying
- [x] I used `make commit` instead of `git commit`
