### PR TITLE
refactor(examples): updated nested folders example

### DIFF
--- a/examples/nested-folders/package.json
+++ b/examples/nested-folders/package.json
@@ -9,7 +9,7 @@
     "@cycle/isolate": "2.0.0-rc.2",
     "@cycle/run": "1.0.0-rc.9",
     "@cycle/dom": "15.0.0-rc.2",
-    "cycle-onionify": "3.0.0-rc.1",
+    "cycle-onionify": "4.0.0",
     "xstream": "10.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Updated the nested folders example to use the new Collection API from the Onionify 4.0 Library.

<!--
Thank you for your contribution! You're awesome.
To help speed up the process of merging your code, check the following:
-->

