### PR TITLE
refactor(dom): use native ES6 Map

### DIFF
--- a/dom/es6-map.d.ts
+++ b/dom/es6-map.d.ts
@@ -1,4 +1,0 @@
-declare module 'es6-map' {
-  const MapPolyfill: {new <K, V>(...args: Array<any>): Map<K, V>};
-  export = MapPolyfill;
-}

--- a/dom/src/IsolateModule.ts
+++ b/dom/src/IsolateModule.ts
@@ -1,6 +1,5 @@
 import {VNode} from 'snabbdom/vnode';
 import {EventDelegator} from './EventDelegator';
-import * as MapPolyfill from 'es6-map';
 
 export class IsolateModule {
   private elementsByFullScope: Map<string, Element>;
@@ -29,11 +28,8 @@ export class IsolateModule {
   private vnodesBeingRemoved: Array<VNode>;
 
   constructor() {
-    this.elementsByFullScope = new MapPolyfill<string, Element>();
-    this.delegatorsByFullScope = new MapPolyfill<
-      string,
-      Array<EventDelegator>
-    >();
+    this.elementsByFullScope = new Map<string, Element>();
+    this.delegatorsByFullScope = new Map<string, Array<EventDelegator>>();
     this.fullScopesBeingUpdated = [];
     this.vnodesBeingRemoved = [];
   }

--- a/dom/src/makeDOMDriver.ts
+++ b/dom/src/makeDOMDriver.ts
@@ -11,7 +11,7 @@ import {getValidNode} from './utils';
 import defaultModules from './modules';
 import {IsolateModule} from './IsolateModule';
 import {EventDelegator} from './EventDelegator';
-import * as MapPolyfill from 'es6-map';
+import 'es6-map/implement'; // tslint:disable-line
 
 function makeDOMDriverInputGuard(modules: any) {
   if (!Array.isArray(modules)) {
@@ -62,7 +62,7 @@ function makeDOMDriver(
   const patch = init([isolateModule.createModule()].concat(modules));
   const rootElement = getValidNode(container) || document.body;
   const vnodeWrapper = new VNodeWrapper(rootElement);
-  const delegators = new MapPolyfill<string, EventDelegator>();
+  const delegators = new Map<string, EventDelegator>();
   makeDOMDriverInputGuard(modules);
 
   function DOMDriver(vnode$: Stream<VNode>, name = 'DOM'): MainDOMSource {

--- a/dom/tsconfig.json
+++ b/dom/tsconfig.json
@@ -12,7 +12,6 @@
     ]
   },
   "files": [
-    "es6-map.d.ts",
     "src/index.ts"
   ]
 }


### PR DESCRIPTION
As stated in the README of es6-map, the algorithmic complexity of the poly-/ponyfill is O(n) not
O(1). As almost all browsers have native ES6 Map support nowadays, we should use them and only
polyfill if needed