### PR TITLE
Remove "change" from eventTypesThatDontBubble

### DIFF
--- a/dom/src/MainDOMSource.ts
+++ b/dom/src/MainDOMSource.ts
@@ -18,7 +18,6 @@ const eventTypesThatDontBubble = [
   `blur`,
   `canplay`,
   `canplaythrough`,
-  `change`,
   `durationchange`,
   `emptied`,
   `ended`,


### PR DESCRIPTION
This fixes an issue I had where a parent component would receive a `change` event from an isolated child component. It seems a trivial bug: `change` is treated as non-bubbling while in fact [it does bubble](https://developer.mozilla.org/en-US/docs/Web/Events/change#General_info).

- [ ] I added new tests for the issue I fixed/built
- [x] I ran `make test FOO` for the package FOO I'm modifying
- [x] I used `make commit` instead of `git commit`
