### PR TITLE
refactor(dom): make DOMSource.elements() monomorphic

### DIFF
--- a/dom/src/BodyDOMSource.ts
+++ b/dom/src/BodyDOMSource.ts
@@ -7,7 +7,7 @@ import {fromEvent} from './fromEvent';
 export class BodyDOMSource implements DOMSource {
   constructor(private _name: string) {}
 
-  public select(selector: string): DOMSource {
+  public select(selector: string): BodyDOMSource {
     // This functionality is still undefined/undecided.
     return this;
   }

--- a/dom/src/DOMSource.ts
+++ b/dom/src/DOMSource.ts
@@ -7,7 +7,9 @@ export interface EventsFnOptions {
 
 export interface DOMSource {
   select(selector: string): DOMSource;
-  elements(): MemoryStream<Document | Element | Array<Element> | string>;
+  elements(): MemoryStream<
+    Document | HTMLBodyElement | Array<Element> | string
+  >;
   events<K extends keyof HTMLElementEventMap>(
     eventType: K,
     options?: EventsFnOptions,

--- a/dom/src/DocumentDOMSource.ts
+++ b/dom/src/DocumentDOMSource.ts
@@ -7,7 +7,7 @@ import {fromEvent} from './fromEvent';
 export class DocumentDOMSource implements DOMSource {
   constructor(private _name: string) {}
 
-  public select(selector: string): DOMSource {
+  public select(selector: string): DocumentDOMSource {
     // This functionality is still undefined/undecided.
     return this;
   }

--- a/dom/src/ElementFinder.ts
+++ b/dom/src/ElementFinder.ts
@@ -13,11 +13,11 @@ export class ElementFinder {
     public isolateModule: IsolateModule,
   ) {}
 
-  public call(rootElement: Element): Element | Array<Element> {
+  public call(rootElement: Element): Array<Element> {
     const namespace = this.namespace;
     const selector = getSelectors(namespace);
     if (!selector) {
-      return rootElement;
+      return [rootElement];
     }
 
     const fullScope = getFullScope(namespace);

--- a/dom/src/MainDOMSource.ts
+++ b/dom/src/MainDOMSource.ts
@@ -88,6 +88,11 @@ function filterBasedOnIsolation(domSource: MainDOMSource, fullScope: string) {
   };
 }
 
+export interface SpecialSelector {
+  body: BodyDOMSource;
+  document: DocumentDOMSource;
+}
+
 export class MainDOMSource implements DOMSource {
   constructor(
     private _rootElement$: Stream<Element>,
@@ -111,10 +116,10 @@ export class MainDOMSource implements DOMSource {
     };
   }
 
-  public elements(): MemoryStream<Element> {
-    let output$: Stream<Element | Array<Element>>;
+  public elements(): MemoryStream<Array<Element>> {
+    let output$: Stream<Array<Element>>;
     if (this._namespace.length === 0) {
-      output$ = this._rootElement$;
+      output$ = this._rootElement$.map(x => [x]);
     } else {
       const elementFinder = new ElementFinder(
         this._namespace,
@@ -122,7 +127,7 @@ export class MainDOMSource implements DOMSource {
       );
       output$ = this._rootElement$.map(el => elementFinder.call(el));
     }
-    const out: DevToolEnabledSource & MemoryStream<Element> = adapt(
+    const out: DevToolEnabledSource & MemoryStream<Array<Element>> = adapt(
       output$.remember(),
     );
     out._isCycleSource = this._name;
@@ -133,6 +138,10 @@ export class MainDOMSource implements DOMSource {
     return this._namespace;
   }
 
+  public select<T extends keyof SpecialSelector>(
+    selector: T,
+  ): SpecialSelector[T];
+  public select(selector: string): MainDOMSource;
   public select(selector: string): DOMSource {
     if (typeof selector !== 'string') {
       throw new Error(
@@ -157,7 +166,7 @@ export class MainDOMSource implements DOMSource {
       this._isolateModule,
       this._delegators,
       this._name,
-    );
+    ) as DOMSource;
   }
 
   public events(

--- a/dom/test/browser/src/dom-driver.ts
+++ b/dom/test/browser/src/dom-driver.ts
@@ -131,8 +131,8 @@ describe('DOM Driver', function() {
     let hasDisposed = false;
     let assertionOngoing = false;
     sources.DOM.select(':root').elements().drop(1).addListener({
-      next: (root: Element) => {
-        const selectEl = root.querySelector('.target') as Element;
+      next: (root: Element[]) => {
+        const selectEl = root[0].querySelector('.target') as Element;
         if (!selectEl && assertionOngoing && hasDisposed) {
           // This synchronous delivery of the empty root element is allowed
           return;

--- a/dom/test/browser/src/elements.ts
+++ b/dom/test/browser/src/elements.ts
@@ -1,0 +1,146 @@
+import * as simulant from 'simulant';
+import * as assert from 'assert';
+import isolate from '@cycle/isolate';
+import xs, {Stream, MemoryStream} from 'xstream';
+import delay from 'xstream/extra/delay';
+import concat from 'xstream/extra/concat';
+import {setup, run} from '@cycle/run';
+import {
+  svg,
+  div,
+  span,
+  h2,
+  h3,
+  h4,
+  p,
+  makeDOMDriver,
+  MainDOMSource,
+  VNode,
+} from '../../../lib';
+
+function createRenderTarget(id: string | null = null) {
+  const element = document.createElement('div');
+  element.className = 'cycletest';
+  if (id) {
+    element.id = id;
+  }
+  document.body.appendChild(element);
+  return element;
+}
+
+describe('DOMSource.elements()', function() {
+  it('should return a stream of documents when querying "document"', function(
+    done,
+  ) {
+    function app(sources: {DOM: MainDOMSource}) {
+      return {
+        DOM: xs.of(div('.top-most', [p('Foo'), span('Bar')])),
+      };
+    }
+
+    const {sinks, sources, run} = setup(app, {
+      DOM: makeDOMDriver(createRenderTarget()),
+    });
+
+    function isDocument(element: any): element is Document {
+      return 'body' in element && 'head' in element;
+    }
+
+    let dispose: any;
+    sources.DOM.select('document').elements().take(1).addListener({
+      next: root => {
+        assert(root.body !== undefined); //Check type inference
+        assert(isDocument(root));
+        setTimeout(() => {
+          dispose();
+          done();
+        });
+      },
+    });
+    dispose = run();
+  });
+
+  it('should return a stream of bodies when querying "body"', function(done) {
+    function app(sources: {DOM: MainDOMSource}) {
+      return {
+        DOM: xs.of(div('.top-most', [p('Foo'), span('Bar')])),
+      };
+    }
+
+    const {sinks, sources, run} = setup(app, {
+      DOM: makeDOMDriver(createRenderTarget()),
+    });
+
+    function isBody(element: any): element is HTMLBodyElement {
+      return 'aLink' in element && 'link' in element;
+    }
+
+    let dispose: any;
+    sources.DOM.select('body').elements().take(1).addListener({
+      next: root => {
+        assert(root.aLink !== undefined); //Check type inference
+        assert(isBody(root));
+        setTimeout(() => {
+          dispose();
+          done();
+        });
+      },
+    });
+    dispose = run();
+  });
+
+  it('should return a stream of arrays of elements of size 1 when querying ":root"', function(
+    done,
+  ) {
+    function app(sources: {DOM: MainDOMSource}) {
+      return {
+        DOM: xs.of(div('.top-most', [p('Foo'), span('Bar')])),
+      };
+    }
+
+    const {sinks, sources, run} = setup(app, {
+      DOM: makeDOMDriver(createRenderTarget()),
+    });
+
+    let dispose: any;
+    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+      next: root => {
+        assert(root.forEach !== undefined); //Check type inference
+        assert(Array.isArray(root));
+        assert(root.length === 1);
+        setTimeout(() => {
+          dispose();
+          done();
+        });
+      },
+    });
+    dispose = run();
+  });
+
+  it('should return a stream of arrays of elements of size 1 when querying ":root"', function(
+    done,
+  ) {
+    function app(sources: {DOM: MainDOMSource}) {
+      return {
+        DOM: xs.of(div('.top-most', [div('.some'), div('.some')])),
+      };
+    }
+
+    const {sinks, sources, run} = setup(app, {
+      DOM: makeDOMDriver(createRenderTarget()),
+    });
+
+    let dispose: any;
+    sources.DOM.select('.some').elements().drop(1).take(1).addListener({
+      next: (elems: Element[]) => {
+        assert(Array.isArray(elems));
+        assert(elems.length === 2);
+        setTimeout(() => {
+          dispose();
+          done();
+        });
+      },
+    });
+    dispose = run();
+  });
+});

--- a/dom/test/browser/src/events.ts
+++ b/dom/test/browser/src/events.ts
@@ -82,8 +82,10 @@ describe('DOMSource.events()', function() {
     });
     // Make assertions
     sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-      next: function(root: Element) {
-        const myElement = root.querySelector('.myelementclass') as HTMLElement;
+      next: function(root: Element[]) {
+        const myElement = root[0].querySelector(
+          '.myelementclass',
+        ) as HTMLElement;
         assert.notStrictEqual(myElement, null);
         assert.notStrictEqual(typeof myElement, 'undefined');
         assert.strictEqual(myElement.tagName, 'H3');
@@ -196,8 +198,10 @@ describe('DOMSource.events()', function() {
     });
 
     sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-      next: (root: Element) => {
-        const myElement = root.querySelector('.myelementclass') as HTMLElement;
+      next: (root: Element[]) => {
+        const myElement = root[0].querySelector(
+          '.myelementclass',
+        ) as HTMLElement;
         assert.notStrictEqual(myElement, null);
         assert.notStrictEqual(typeof myElement, 'undefined');
         assert.strictEqual(myElement.tagName, 'H3');
@@ -234,8 +238,8 @@ describe('DOMSource.events()', function() {
     });
 
     sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-      next: (root: Element) => {
-        const myElement = root.querySelector('#myElementId') as HTMLElement;
+      next: (root: Element[]) => {
+        const myElement = root[0].querySelector('#myElementId') as HTMLElement;
         assert.notStrictEqual(myElement, null);
         assert.notStrictEqual(typeof myElement, 'undefined');
         assert.strictEqual(myElement.tagName, 'H3');
@@ -270,8 +274,10 @@ describe('DOMSource.events()', function() {
     });
 
     sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-      next: (root: Element) => {
-        const myElement = root.querySelector('.myelementclass') as HTMLElement;
+      next: (root: Element[]) => {
+        const myElement = root[0].querySelector(
+          '.myelementclass',
+        ) as HTMLElement;
         assert.notStrictEqual(myElement, null);
         assert.notStrictEqual(typeof myElement, 'undefined');
         assert.strictEqual(myElement.tagName, 'H3');
@@ -313,9 +319,11 @@ describe('DOMSource.events()', function() {
     });
 
     sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-      next: (root: Element) => {
-        const wrongElement = root.querySelector('.bar') as HTMLElement;
-        const correctElement = root.querySelector('.foo .bar') as HTMLElement;
+      next: (root: Element[]) => {
+        const wrongElement = root[0].querySelector('.bar') as HTMLElement;
+        const correctElement = root[0].querySelector(
+          '.foo .bar',
+        ) as HTMLElement;
         assert.notStrictEqual(wrongElement, null);
         assert.notStrictEqual(correctElement, null);
         assert.notStrictEqual(typeof wrongElement, 'undefined');
@@ -373,9 +381,9 @@ describe('DOMSource.events()', function() {
       });
 
     sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-      next: (root: Element) => {
-        const firstElem = root.querySelector('.first') as HTMLElement;
-        const secondElem = root.querySelector('.second') as HTMLElement;
+      next: (root: Element[]) => {
+        const firstElem = root[0].querySelector('.first') as HTMLElement;
+        const secondElem = root[0].querySelector('.second') as HTMLElement;
         assert.notStrictEqual(firstElem, null);
         assert.notStrictEqual(typeof firstElem, 'undefined');
         assert.notStrictEqual(secondElem, null);
@@ -416,8 +424,8 @@ describe('DOMSource.events()', function() {
     });
 
     sources.DOM.select(':root').elements().drop(3).take(1).addListener({
-      next: (root: Element) => {
-        const myElement = root.querySelector('.blosh') as HTMLElement;
+      next: (root: Element[]) => {
+        const myElement = root[0].querySelector('.blosh') as HTMLElement;
         assert.notStrictEqual(myElement, null);
         assert.notStrictEqual(typeof myElement, 'undefined');
         assert.strictEqual(myElement.tagName, 'H4');
@@ -468,8 +476,8 @@ describe('DOMSource.events()', function() {
         });
 
       sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-        next: (root: Element) => {
-          const clickable = root.querySelector('.clickable') as HTMLElement;
+        next: (root: Element[]) => {
+          const clickable = root[0].querySelector('.clickable') as HTMLElement;
           setTimeout(() => clickable.click(), 80);
         },
       });
@@ -517,8 +525,8 @@ describe('DOMSource.events()', function() {
         });
 
       sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-        next: (root: Element) => {
-          const clickable = root.querySelector('.clickable') as HTMLElement;
+        next: (root: Element[]) => {
+          const clickable = root[0].querySelector('.clickable') as HTMLElement;
           setTimeout(() => clickable.click(), 80);
         },
       });
@@ -567,8 +575,8 @@ describe('DOMSource.events()', function() {
 
     // Make assertions
     sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-      next: (root: Element) => {
-        const child = root.querySelector('.child') as HTMLElement;
+      next: (root: Element[]) => {
+        const child = root[0].querySelector('.child') as HTMLElement;
         assert.notStrictEqual(child, null);
         assert.notStrictEqual(typeof child, 'undefined');
         assert.strictEqual(child.tagName, 'SPAN');
@@ -605,8 +613,8 @@ describe('DOMSource.events()', function() {
     });
 
     sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-      next: (root: Element) => {
-        const form = root.querySelector('.form') as HTMLFormElement;
+      next: (root: Element[]) => {
+        const form = root[0].querySelector('.form') as HTMLFormElement;
         setTimeout(() => form.reset());
       },
     });
@@ -670,8 +678,8 @@ describe('DOMSource.events()', function() {
       });
 
     sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-      next: (root: Element) => {
-        const clickable = root.querySelector('.clickable') as HTMLElement;
+      next: (root: Element[]) => {
+        const clickable = root[0].querySelector('.clickable') as HTMLElement;
         setTimeout(() => click(clickable));
       },
     });
@@ -710,10 +718,10 @@ describe('DOMSource.events()', function() {
         });
 
       sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-        next: (root: Element) => {
-          const correct = root.querySelector('.correct') as HTMLElement;
-          const wrong = root.querySelector('.wrong') as HTMLElement;
-          const dummy = root.querySelector('.dummy') as HTMLElement;
+        next: (root: Element[]) => {
+          const correct = root[0].querySelector('.correct') as HTMLElement;
+          const wrong = root[0].querySelector('.wrong') as HTMLElement;
+          const dummy = root[0].querySelector('.dummy') as HTMLElement;
           setTimeout(() => wrong.focus(), 50);
           setTimeout(() => dummy.focus(), 100);
           setTimeout(() => correct.focus(), 150);
@@ -753,10 +761,10 @@ describe('DOMSource.events()', function() {
       });
 
       sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-        next: (root: Element) => {
-          const correct = root.querySelector('.correct') as HTMLElement;
-          const wrong = root.querySelector('.wrong') as HTMLElement;
-          const dummy = root.querySelector('.dummy') as HTMLElement;
+        next: (root: Element[]) => {
+          const correct = root[0].querySelector('.correct') as HTMLElement;
+          const wrong = root[0].querySelector('.wrong') as HTMLElement;
+          const dummy = root[0].querySelector('.dummy') as HTMLElement;
           setTimeout(() => wrong.focus(), 50);
           setTimeout(() => dummy.focus(), 100);
           setTimeout(() => correct.focus(), 150);
@@ -801,8 +809,8 @@ describe('DOMSource.events()', function() {
       });
 
     sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-      next: (root: Element) => {
-        const form = root.querySelector('.form') as HTMLFormElement;
+      next: (root: Element[]) => {
+        const form = root[0].querySelector('.form') as HTMLFormElement;
         setTimeout(() => form.reset());
       },
     });
@@ -897,8 +905,8 @@ describe('DOMSource.events()', function() {
     });
 
     sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-      next: (root: Element) => {
-        const clickable = root.querySelector('.item') as HTMLElement;
+      next: (root: Element[]) => {
+        const clickable = root[0].querySelector('.item') as HTMLElement;
         setTimeout(() => switchSubject.shamefullySendNext(null));
         setTimeout(() => mouseevent(clickable, 'mousedown'), 100);
         setTimeout(() => mouseevent(clickable, 'mouseup'), 200);
@@ -936,8 +944,8 @@ describe('DOMSource.events()', function() {
       });
 
     sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-      next: (root: Element) => {
-        const button = root.querySelector('.button') as HTMLButtonElement;
+      next: (root: Element[]) => {
+        const button = root[0].querySelector('.button') as HTMLButtonElement;
         setTimeout(() => button.click());
       },
     });
@@ -972,8 +980,8 @@ describe('DOMSource.events()', function() {
       });
 
     sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-      next: (root: Element) => {
-        const button = root.querySelector('.button') as HTMLButtonElement;
+      next: (root: Element[]) => {
+        const button = root[0].querySelector('.button') as HTMLButtonElement;
         setTimeout(() => button.click());
       },
     });
@@ -1008,8 +1016,8 @@ describe('DOMSource.events()', function() {
       });
 
     sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-      next: (root: Element) => {
-        const button = root.querySelector('.button') as HTMLButtonElement;
+      next: (root: Element[]) => {
+        const button = root[0].querySelector('.button') as HTMLButtonElement;
         setTimeout(() => button.click());
       },
     });
@@ -1046,8 +1054,8 @@ describe('DOMSource.events()', function() {
       });
 
     sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-      next: (root: Element) => {
-        const button = root.querySelector('.button') as HTMLButtonElement;
+      next: (root: Element[]) => {
+        const button = root[0].querySelector('.button') as HTMLButtonElement;
         setTimeout(() => button.click());
       },
     });
@@ -1082,8 +1090,8 @@ describe('DOMSource.events()', function() {
       });
 
     sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-      next: (root: Element) => {
-        const button = root.querySelector('.button') as HTMLButtonElement;
+      next: (root: Element[]) => {
+        const button = root[0].querySelector('.button') as HTMLButtonElement;
         setTimeout(() => button.click());
       },
     });
@@ -1118,8 +1126,8 @@ describe('DOMSource.events()', function() {
       });
 
     sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-      next: (root: Element) => {
-        const button = root.querySelector('.button') as HTMLButtonElement;
+      next: (root: Element[]) => {
+        const button = root[0].querySelector('.button') as HTMLButtonElement;
         setTimeout(() => button.click());
       },
     });
@@ -1156,8 +1164,8 @@ describe('DOMSource.events()', function() {
       });
 
     sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-      next: (root: Element) => {
-        const button = root.querySelector('.button') as HTMLButtonElement;
+      next: (root: Element[]) => {
+        const button = root[0].querySelector('.button') as HTMLButtonElement;
         setTimeout(() => button.click());
       },
     });

--- a/dom/test/browser/src/index.ts
+++ b/dom/test/browser/src/index.ts
@@ -2,4 +2,5 @@ import './dom-driver';
 import './render';
 import './events';
 import './select';
+import './elements';
 import './isolation';

--- a/dom/test/browser/src/isolation.ts
+++ b/dom/test/browser/src/isolation.ts
@@ -403,7 +403,9 @@ describe('isolation', function() {
   it('should allow using elements() in an isolated main() fn', function(done) {
     function main(sources) {
       const elem$ = sources.DOM.select(':root').elements();
-      const vnode$ = elem$.map(elem => h('div.bar', 'left=' + elem.offsetLeft));
+      const vnode$ = elem$.map(elem =>
+        h('div.bar', 'left=' + elem[0].offsetLeft),
+      );
       return {
         DOM: vnode$,
       };
@@ -414,8 +416,8 @@ describe('isolation', function() {
     });
 
     sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-      next: (rootElement: Element) => {
-        const barElem = rootElement.querySelector('.bar') as Element;
+      next: (root: Element[]) => {
+        const barElem = root[0].querySelector('.bar') as Element;
         assert.notStrictEqual(barElem, null);
         assert.notStrictEqual(typeof barElem, 'undefined');
         assert.strictEqual(barElem.tagName, 'DIV');
@@ -562,9 +564,11 @@ describe('isolation', function() {
     });
 
     sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-      next: (root: Element) => {
-        const frameFoo = root.querySelector('.foo.frame') as HTMLElement;
-        const monalisaFoo = root.querySelector('.foo.monalisa') as HTMLElement;
+      next: (root: Element[]) => {
+        const frameFoo = root[0].querySelector('.foo.frame') as HTMLElement;
+        const monalisaFoo = root[0].querySelector(
+          '.foo.monalisa',
+        ) as HTMLElement;
         assert.notStrictEqual(frameFoo, null);
         assert.notStrictEqual(monalisaFoo, null);
         assert.notStrictEqual(typeof frameFoo, 'undefined');
@@ -982,8 +986,8 @@ describe('isolation', function() {
 
     let dispose: any;
     sources.DOM.select(':root').elements().drop(2).take(1).addListener({
-      next: (root: Element) => {
-        const parentEl = root.querySelector('.parent') as HTMLElement;
+      next: (root: Element[]) => {
+        const parentEl = root[0].querySelector('.parent') as HTMLElement;
         const foo = parentEl.querySelectorAll('.foo')[1] as HTMLElement;
         assert.notStrictEqual(parentEl, null);
         assert.notStrictEqual(typeof parentEl, 'undefined');
@@ -1039,13 +1043,13 @@ describe('isolation', function() {
 
     let dispose: any;
     sources.DOM.select(':root').elements().drop(1).take(3).addListener({
-      next: (root: any) => {
+      next: (root: Element[]) => {
         setTimeout(() => {
-          const foo = root.querySelector('.foo');
+          const foo = root[0].querySelector('.foo');
           if (!foo) {
             return;
           }
-          foo.click();
+          (foo as any).click();
         }, 0);
       },
     });
@@ -1091,13 +1095,13 @@ describe('isolation', function() {
 
     let dispose: any;
     sources.DOM.select(':root').elements().drop(1).take(4).addListener({
-      next: (root: any) => {
+      next: (root: Element[]) => {
         setTimeout(() => {
-          const foo = root.querySelector('.foo');
+          const foo = root[0].querySelector('.foo');
           if (!foo) {
             return;
           }
-          foo.click();
+          (foo as any).click();
         }, 0);
       },
     });
@@ -1150,13 +1154,13 @@ describe('isolation', function() {
 
     let dispose: any;
     sources.DOM.select(':root').elements().drop(1).take(4).addListener({
-      next: (root: any) => {
+      next: (root: Element[]) => {
         setTimeout(() => {
-          const foo = root.querySelector('.foo');
+          const foo = root[0].querySelector('.foo');
           if (!foo) {
             return;
           }
-          foo.click();
+          (foo as any).click();
         }, 0);
       },
     });
@@ -1200,8 +1204,8 @@ describe('isolation', function() {
       });
 
       sources.DOM.elements().drop(1).take(1).addListener({
-        next: (root: Element) => {
-          const element = root.querySelector('.btn') as HTMLElement;
+        next: (root: Element[]) => {
+          const element = root[0].querySelector('.btn') as HTMLElement;
           assert.notStrictEqual(element, null);
           setTimeout(() => element.click());
         },
@@ -1244,8 +1248,8 @@ describe('isolation', function() {
       });
 
       sources.DOM.elements().drop(1).take(1).addListener({
-        next: (root: Element) => {
-          const element = root.querySelector('.btn') as HTMLElement;
+        next: (root: Element[]) => {
+          const element = root[0].querySelector('.btn') as HTMLElement;
           assert.notStrictEqual(element, null);
           setTimeout(() => element.click());
         },
@@ -1288,8 +1292,8 @@ describe('isolation', function() {
       });
 
       sources.DOM.elements().drop(1).take(1).addListener({
-        next: (root: Element) => {
-          const element = root.querySelector('.btn') as HTMLElement;
+        next: (root: Element[]) => {
+          const element = root[0].querySelector('.btn') as HTMLElement;
           assert.notStrictEqual(element, null);
           setTimeout(() => element.click());
         },
@@ -1332,8 +1336,8 @@ describe('isolation', function() {
       });
 
       sources.DOM.elements().drop(1).take(1).addListener({
-        next: (root: Element) => {
-          const element = root.querySelector('.btn') as HTMLElement;
+        next: (root: Element[]) => {
+          const element = root[0].querySelector('.btn') as HTMLElement;
           assert.notStrictEqual(element, null);
           setTimeout(() => element.click());
         },
@@ -1389,8 +1393,8 @@ describe('isolation', function() {
 
       let dispose: any;
       sources.DOM.elements().drop(1).take(1).addListener({
-        next: (root: Element) => {
-          const components = root.querySelectorAll('.btn');
+        next: (root: Element[]) => {
+          const components = root[0].querySelectorAll('.btn');
           assert.strictEqual(components.length, 2);
           const firstElement = components[0] as HTMLElement;
           const secondElement = components[1] as HTMLElement;
@@ -1401,7 +1405,10 @@ describe('isolation', function() {
             secondElement.click();
           }, 300);
           setTimeout(() => {
-            assert.strictEqual(root.querySelectorAll('.component').length, 0);
+            assert.strictEqual(
+              root[0].querySelectorAll('.component').length,
+              0,
+            );
             dispose();
             done();
           }, 500);
@@ -1436,8 +1443,8 @@ describe('isolation', function() {
 
     let dispose: any;
     sources.DOM.elements().drop(1).take(1).addListener({
-      next: (root: Element) => {
-        const parentEl = root.querySelector('.parent') as Element;
+      next: (root: Element[]) => {
+        const parentEl = root[0].querySelector('.parent') as Element;
         assert.strictEqual(parentEl.childNodes.length, 2);
         assert.strictEqual(parentEl.children[0].tagName, 'H4');
         assert.strictEqual(parentEl.children[0].textContent, 'child');
@@ -1446,8 +1453,8 @@ describe('isolation', function() {
       },
     });
     sources.DOM.elements().drop(2).take(1).addListener({
-      next: (root: Element) => {
-        const parentEl = root.querySelector('.parent') as Element;
+      next: (root: Element[]) => {
+        const parentEl = root[0].querySelector('.parent') as Element;
         assert.strictEqual(parentEl.childNodes.length, 1);
         assert.strictEqual(parentEl.children[0].tagName, 'H2');
         assert.strictEqual(parentEl.children[0].textContent, 'part of parent');
@@ -1492,8 +1499,8 @@ describe('isolation', function() {
 
     let dispose: any;
     sources.DOM.elements().drop(1).take(1).addListener({
-      next: (root: Element) => {
-        const buttons = root.querySelectorAll('.btn');
+      next: (root: Element[]) => {
+        const buttons = root[0].querySelectorAll('.btn');
         assert.strictEqual(buttons.length, 4);
         const firstButton = buttons[0];
         const secondButton = buttons[1];
@@ -1565,8 +1572,8 @@ describe('isolation', function() {
     });
 
     sources.DOM.select(':root').elements().drop(1).addListener({
-      next: function(root: Element) {
-        const button = root.querySelector('button.click-me') as HTMLElement;
+      next: function(root: Element[]) {
+        const button = root[0].querySelector('button.click-me') as HTMLElement;
         button.click();
       },
     });

--- a/dom/test/browser/src/render.tsx
+++ b/dom/test/browser/src/render.tsx
@@ -96,8 +96,8 @@ describe('DOM Rendering', function () {
 
       let dispose: any;
       sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-        next: (root: Element) => {
-          const elem = root.querySelector('.my-class') as HTMLElement;
+        next: (root: Element[]) => {
+          const elem = root[0].querySelector('.my-class') as HTMLElement;
           assert.notStrictEqual(elem, null);
           assert.notStrictEqual(typeof elem, 'undefined');
           assert.strictEqual(elem.tagName, 'DIV');
@@ -131,8 +131,8 @@ describe('DOM Rendering', function () {
 
     let dispose: any;
     sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-      next: (root: Element) => {
-        const selectEl = root.querySelector('.my-class') as HTMLElement;
+      next: (root: Element[]) => {
+        const selectEl = root[0].querySelector('.my-class') as HTMLElement;
         assert.notStrictEqual(selectEl, null);
         assert.notStrictEqual(typeof selectEl, 'undefined');
         assert.strictEqual(selectEl.tagName, 'SELECT');
@@ -164,8 +164,8 @@ describe('DOM Rendering', function () {
 
     let dispose: any;
     sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-      next: (root: Element) => {
-        const selectEl = root.querySelector('.my-class') as HTMLElement;
+      next: (root: Element[]) => {
+        const selectEl = root[0].querySelector('.my-class') as HTMLElement;
         assert.notStrictEqual(selectEl, null);
         assert.notStrictEqual(typeof selectEl, 'undefined');
         assert.strictEqual(selectEl.tagName, 'SELECT');
@@ -197,8 +197,8 @@ describe('DOM Rendering', function () {
 
     let dispose: any;
     sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-      next: (root: Element) => {
-        const selectEl = root.querySelector('.my-class') as HTMLSelectElement;
+      next: (root: Element[]) => {
+        const selectEl = root[0].querySelector('.my-class') as HTMLSelectElement;
         assert.notStrictEqual(selectEl, null);
         assert.notStrictEqual(typeof selectEl, 'undefined');
         assert.strictEqual(selectEl.tagName, 'SELECT');
@@ -242,9 +242,9 @@ describe('DOM Rendering', function () {
 
     let dispose: any;
     sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-      next: (root: Element) => {
-        assert.strictEqual(root.childNodes.length, 1);
-        const selectEl = root.childNodes[0] as HTMLElement;
+      next: (root: Element[]) => {
+        assert.strictEqual(root[0].childNodes.length, 1);
+        const selectEl = root[0].childNodes[0] as HTMLElement;
         assert.strictEqual(selectEl.tagName, 'SELECT');
         assert.strictEqual(selectEl.childNodes.length, 3);
         const option1 = selectEl.childNodes[0] as HTMLElement;
@@ -286,10 +286,10 @@ describe('DOM Rendering', function () {
     const element$ = sources.DOM.select(':root').elements();
 
     element$.drop(1).take(1).addListener({
-      next: (root: Element) => {
+      next: (root: Element[]) => {
         assert.strictEqual(firstSubscriberRan, false);
         firstSubscriberRan = true;
-        const header = root.querySelector('.value-over-time') as HTMLElement;
+        const header = root[0].querySelector('.value-over-time') as HTMLElement;
         assert.notStrictEqual(header, null);
         assert.notStrictEqual(typeof header, 'undefined');
         assert.strictEqual(header.tagName, 'H2');
@@ -301,10 +301,10 @@ describe('DOM Rendering', function () {
       // some element into the subscriber.
       assert.strictEqual(secondSubscriberRan, false);
       element$.take(1).addListener({
-        next: (root: Element) => {
+        next: (root: Element[]) => {
           assert.strictEqual(secondSubscriberRan, false);
           secondSubscriberRan = true;
-          const header = root.querySelector('.value-over-time') as HTMLElement;
+          const header = root[0].querySelector('.value-over-time') as HTMLElement;
           assert.notStrictEqual(header, null);
           assert.notStrictEqual(typeof header, 'undefined');
           assert.strictEqual(header.tagName, 'H2');
@@ -362,8 +362,8 @@ describe('DOM Rendering', function () {
     let dispose: any;
     // Assert it
     sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-      next: (root: Element) => {
-        const h4Elem = root.querySelector('h4') as HTMLElement;
+      next: (root: Element[]) => {
+        const h4Elem = root[0].querySelector('h4') as HTMLElement;
         assert.notStrictEqual(h4Elem, null);
         assert.notStrictEqual(typeof h4Elem, 'undefined');
         assert.strictEqual(h4Elem.tagName, 'H4');
@@ -403,8 +403,8 @@ describe('DOM Rendering', function () {
 
       // Make assertions
       sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-        next: (root: Element) => {
-          const embeddedHTML = root.querySelector('p.embedded-text') as HTMLElement;
+        next: (root: Element[]) => {
+          const embeddedHTML = root[0].querySelector('p.embedded-text') as HTMLElement;
           assert.strictEqual(embeddedHTML.namespaceURI, 'http://www.w3.org/1999/xhtml');
           assert.notStrictEqual(embeddedHTML.clientWidth, 0);
           assert.notStrictEqual(embeddedHTML.clientHeight, 0);
@@ -449,10 +449,10 @@ describe('DOM Rendering', function () {
     let dispose: any;
     // Assert it
     sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-      next: (root: Element) => {
-        const divParent = root.querySelector('div.parent') as HTMLElement;
-        const h4Child = root.querySelector('h4.child3') as HTMLElement;
-        const grandchild = root.querySelector('div.grandchild32') as HTMLElement;
+      next: (root: Element[]) => {
+        const divParent = root[0].querySelector('div.parent') as HTMLElement;
+        const h4Child = root[0].querySelector('h4.child3') as HTMLElement;
+        const grandchild = root[0].querySelector('div.grandchild32') as HTMLElement;
         assert.strictEqual(divParent.childNodes.length, 2);
         assert.strictEqual(h4Child.childNodes.length, 2);
         assert.strictEqual(grandchild.childNodes.length, 1);
@@ -476,8 +476,8 @@ describe('DOM Rendering', function () {
 
     let dispose: any;
     sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-      next: (root: Element) => {
-        const H4 = root.querySelector('h4') as HTMLElement;
+      next: (root: Element[]) => {
+        const H4 = root[0].querySelector('h4') as HTMLElement;
         assert.strictEqual(H4.textContent, 'Hello world');
         setTimeout(() => {
           dispose();
@@ -501,8 +501,8 @@ describe('DOM Rendering', function () {
 
     let dispose: any;
     sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-      next: (root: Element) => {
-        const divEl = root.querySelector('.my-class') as HTMLElement;
+      next: (root: Element[]) => {
+        const divEl = root[0].querySelector('.my-class') as HTMLElement;
         assert.strictEqual(divEl.textContent, '0');
         setTimeout(() => {
           dispose();

--- a/dom/test/browser/src/select.ts
+++ b/dom/test/browser/src/select.ts
@@ -42,10 +42,10 @@ describe('DOMSource.select()', function() {
 
     let dispose: any;
     sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-      next: (root: Element) => {
+      next: (root: Element[]) => {
         const classNameRegex = /top\-most/;
-        assert.strictEqual(root.tagName, 'DIV');
-        const child = root.children[0];
+        assert.strictEqual(root[0].tagName, 'DIV');
+        const child = root[0].children[0];
         const execResult = classNameRegex.exec(child.className);
         assert.notStrictEqual(execResult, null);
         assert.strictEqual((execResult as any)[0], 'top-most');


### PR DESCRIPTION
MainDOMSource.elements() now always returns an array of Elements, return types of the other
DOMSources are correctly inferred

ISSUES CLOSED: #677

- [x] I added new tests for the issue I fixed/built
- [x] I ran `make test FOO` for the package FOO I'm modifying
- [x] I used `make commit` instead of `git commit`
