### PR TITLE
chore(META): make relative paths of cjs and es6 build the same

### DIFF
--- a/.scripts/make-api-docs.js
+++ b/.scripts/make-api-docs.js
@@ -10,7 +10,7 @@ var argPackage = process.argv[2];
 var dirOfThePackage = __dirname + '/../' + argPackage;
 
 markdox.process(
-  dirOfThePackage + '/lib/index.js', // src
+  dirOfThePackage + '/lib/cjs/index.js', // src
   {
     output: dirOfThePackage + '/generated-api.md',
     template: __dirname + '/api-ref-template.md.ejs',

--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,9 @@ lib :
 	else \
 		rm -rf $(ARG)/lib/ ;\
 		mkdir -p $(ARG)/lib ;\
-		$(TSC) --project $(ARG) --module commonjs --outDir $(ARG)/lib ;\
+		$(TSC) --project $(ARG) --module commonjs --outDir $(ARG)/lib/cjs ;\
 		$(TSC) --project $(ARG) --module es6 --outDir $(ARG)/lib/es6 ;\
+		grep 'postlib' $(ARG)/package.json >/dev/null && cd $(ARG) && npm run postlib ;\
 		echo "✓ Compiled TypeScript to lib\n" ;\
 	fi
 

--- a/dom/package.json
+++ b/dom/package.json
@@ -29,10 +29,10 @@
     "mvi",
     "virtual-dom"
   ],
-  "main": "lib/index.js",
+  "main": "lib/cjs/index.js",
   "module": "lib/es6/index.js",
-  "typings": "lib/index.d.ts",
-  "types": "lib/index.d.ts",
+  "typings": "lib/cjs/index.d.ts",
+  "types": "lib/cjs/index.d.ts",
   "dependencies": {
     "@cycle/run": "*",
     "es6-map": "^0.1.4",

--- a/dom/test/browser/src/dom-driver.ts
+++ b/dom/test/browser/src/dom-driver.ts
@@ -4,7 +4,13 @@ import xs, {Stream, MemoryStream} from 'xstream';
 import delay from 'xstream/extra/delay';
 import flattenSequentially from 'xstream/extra/flattenSequentially';
 import {setup, run} from '@cycle/run';
-import {div, h3, makeDOMDriver, DOMSource, MainDOMSource} from '../../../lib';
+import {
+  div,
+  h3,
+  makeDOMDriver,
+  DOMSource,
+  MainDOMSource,
+} from '../../../lib/cjs/index';
 
 function createRenderTarget(id: string | null = null) {
   const element = document.createElement('div');

--- a/dom/test/browser/src/elements.ts
+++ b/dom/test/browser/src/elements.ts
@@ -16,7 +16,7 @@ import {
   makeDOMDriver,
   MainDOMSource,
   VNode,
-} from '../../../lib';
+} from '../../../lib/cjs/index';
 
 function createRenderTarget(id: string | null = null) {
   const element = document.createElement('div');

--- a/dom/test/browser/src/events.ts
+++ b/dom/test/browser/src/events.ts
@@ -15,7 +15,7 @@ import {
   button,
   makeDOMDriver,
   DOMSource,
-} from '../../../lib';
+} from '../../../lib/cjs/index';
 
 function createRenderTarget(id: string | null = null) {
   const element = document.createElement('div');

--- a/dom/test/browser/src/isolation.ts
+++ b/dom/test/browser/src/isolation.ts
@@ -19,7 +19,7 @@ import {
   MainDOMSource,
   VNode,
   thunk,
-} from '../../../lib';
+} from '../../../lib/cjs/index';
 
 function createRenderTarget(id: string | null = null) {
   const element = document.createElement('div');

--- a/dom/test/browser/src/render.tsx
+++ b/dom/test/browser/src/render.tsx
@@ -22,7 +22,7 @@ import {
   DOMSource,
   MainDOMSource,
   VNode,
-} from '../../../lib';
+} from '../../../lib/cjs/index';
 const {html} = snabbdomJSX;
 
 declare global {

--- a/dom/test/browser/src/select.ts
+++ b/dom/test/browser/src/select.ts
@@ -16,7 +16,7 @@ import {
   makeDOMDriver,
   MainDOMSource,
   VNode,
-} from '../../../lib';
+} from '../../../lib/cjs/index';
 
 function createRenderTarget(id: string | null = null) {
   const element = document.createElement('div');

--- a/dom/test/manual-tests/advanced-list/src/app.js
+++ b/dom/test/manual-tests/advanced-list/src/app.js
@@ -1,5 +1,5 @@
 import xs from 'xstream';
-import {h3, div} from '../../../../lib/index';
+import {h3, div} from '../../../../lib/cjs/index';
 import isolate from '@cycle/isolate';
 import Ticker from './ticker.js';
 

--- a/dom/test/manual-tests/advanced-list/src/main.js
+++ b/dom/test/manual-tests/advanced-list/src/main.js
@@ -1,5 +1,5 @@
 import {run} from '@cycle/xstream-run';
-import {makeDOMDriver} from '../../../../lib/index';
+import {makeDOMDriver} from '../../../../lib/cjs/index';
 import App from './app.js';
 
 const main = App;

--- a/dom/test/manual-tests/advanced-list/src/ticker.js
+++ b/dom/test/manual-tests/advanced-list/src/ticker.js
@@ -1,6 +1,6 @@
 import xs from 'xstream';
 import delay from 'xstream/extra/delay';
-import {div, h1, h4, button} from '../../../../lib/index';
+import {div, h1, h4, button} from '../../../../lib/cjs/index';
 
 function intent(DOMSource) {
   const removeClicks$ = DOMSource.select('.remove-btn').events('click');

--- a/dom/test/node/mock-dom-source.ts
+++ b/dom/test/node/mock-dom-source.ts
@@ -3,7 +3,15 @@ import * as assert from 'assert';
 import * as Rx from 'rxjs';
 import {Observable} from 'rxjs';
 import {setup} from '@cycle/rxjs-run';
-import {h3, h4, h2, div, h, mockDOMSource, MockedDOMSource} from '../../lib';
+import {
+  h3,
+  h4,
+  h2,
+  div,
+  h,
+  mockDOMSource,
+  MockedDOMSource,
+} from '../../lib/cjs/index';
 
 describe('mockDOMSource', function() {
   it('should be in accessible in the API', function() {

--- a/history/package.json
+++ b/history/package.json
@@ -2,10 +2,10 @@
   "name": "@cycle/history",
   "version": "6.5.0",
   "description": "The standard history driver for Cycle.js",
-  "main": "lib/index.js",
+  "main": "lib/cjs/index.js",
   "module": "lib/es6/index.js",
-  "typings": "lib/index.d.ts",
-  "types": "lib/index.d.ts",
+  "typings": "lib/cjs/index.d.ts",
+  "types": "lib/cjs/index.d.ts",
   "directories": {
     "test": "test"
   },

--- a/html/package.json
+++ b/html/package.json
@@ -29,10 +29,10 @@
     "mvi",
     "virtual-dom"
   ],
-  "main": "lib/index.js",
+  "main": "lib/cjs/index.js",
   "module": "lib/es6/index.js",
-  "typings": "lib/index.d.ts",
-  "types": "lib/index.d.ts",
+  "typings": "lib/cjs/index.d.ts",
+  "types": "lib/cjs/index.d.ts",
   "dependencies": {
     "@cycle/run": "*",
     "@cycle/dom": "18.x",

--- a/html/test/index.ts
+++ b/html/test/index.ts
@@ -3,7 +3,7 @@ import * as assert from 'assert';
 import xs, {Stream} from 'xstream';
 import {setup, run} from '@cycle/run';
 import {div, h3, h2, h, VNode} from '@cycle/dom';
-import {makeHTMLDriver, HTMLSource} from '../lib';
+import {makeHTMLDriver, HTMLSource} from '../lib/cjs/index';
 
 describe('HTML Driver', function() {
   it('should output HTML when given a simple vtree stream', function(done) {

--- a/http/most-typings.d.ts
+++ b/http/most-typings.d.ts
@@ -1,8 +1,16 @@
-import {ResponseStream, Response, RequestOptions, RequestInput} from './lib/interfaces';
+import {
+  ResponseStream,
+  Response,
+  RequestOptions,
+  RequestInput,
+} from './lib/cjs/interfaces';
 import {Stream} from 'most';
 export interface HTTPSource {
   filter(predicate: (request: RequestOptions) => boolean): HTTPSource;
   select(category?: string): Stream<Stream<Response> & ResponseStream>;
   isolateSource: (source: HTTPSource, scope: string | null) => HTTPSource;
-  isolateSink: (sink: Stream<RequestInput | string>, scope: string | null) => Stream<RequestInput>;
+  isolateSink: (
+    sink: Stream<RequestInput | string>,
+    scope: string | null,
+  ) => Stream<RequestInput>;
 }

--- a/http/package.json
+++ b/http/package.json
@@ -2,9 +2,9 @@
   "name": "@cycle/http",
   "version": "14.5.0",
   "description": "A Cycle.js Driver for making HTTP requests",
-  "main": "lib/index.js",
+  "main": "lib/cjs/index.js",
   "module": "lib/es6/index.js",
-  "typings": "lib/index.d.ts",
+  "typings": "lib/cjs/index.d.ts",
   "license": "MIT",
   "repository": "https://github.com/cyclejs/cyclejs/tree/master/http",
   "dependencies": {

--- a/http/rxjs-typings.d.ts
+++ b/http/rxjs-typings.d.ts
@@ -1,8 +1,16 @@
-import {ResponseStream, Response, RequestOptions, RequestInput} from './lib/interfaces';
+import {
+  ResponseStream,
+  Response,
+  RequestOptions,
+  RequestInput,
+} from './lib/cjs/interfaces';
 import {Observable} from 'rxjs';
 export interface HTTPSource {
   filter(predicate: (request: RequestOptions) => boolean): HTTPSource;
   select(category?: string): Observable<Observable<Response> & ResponseStream>;
   isolateSource: (source: HTTPSource, scope: string | null) => HTTPSource;
-  isolateSink: (sink: Observable<RequestInput | string>, scope: string | null) => Observable<RequestInput>;
+  isolateSink: (
+    sink: Observable<RequestInput | string>,
+    scope: string | null,
+  ) => Observable<RequestInput>;
 }

--- a/http/test/browser/src/common.ts
+++ b/http/test/browser/src/common.ts
@@ -4,7 +4,7 @@ import {
   RequestInput,
   Response,
   ResponseStream,
-} from '../../../lib/index';
+} from '../../../lib/cjs/index';
 import {HTTPSource} from '../../../rxjs-typings';
 import * as Rx from 'rxjs';
 import {Observable} from 'rxjs';

--- a/http/test/browser/src/common.ts
+++ b/http/test/browser/src/common.ts
@@ -39,7 +39,7 @@ export function run(uri: string) {
         next: () => {
           done('next should not be called');
         },
-        error: err => {
+        error: (err: any) => {
           assert.strictEqual(
             err.message,
             'Observable of requests given to ' +
@@ -70,7 +70,7 @@ export function run(uri: string) {
         next: () => {
           done('next should not be called');
         },
-        error: err => {
+        error: (err: any) => {
           assert.strictEqual(
             err.message,
             'Please provide a `url` property in the request ' + 'options.',
@@ -102,7 +102,7 @@ export function run(uri: string) {
           assert.strictEqual(typeof response$.request, 'object');
           assert.strictEqual(response$.request.url, uri + '/hello');
           assert.strictEqual(typeof response$.switchMap, 'function'); // is RxJS v5
-          response$.subscribe(function(response) {
+          response$.subscribe(function(response: any) {
             assert.strictEqual(response.status, 200);
             assert.strictEqual(response.text, 'Hello World');
             done();
@@ -151,7 +151,7 @@ export function run(uri: string) {
         assert.strictEqual(response$.request.method, 'POST');
         assert.strictEqual((response$.request.send as any).name, 'Woof');
         assert.strictEqual((response$.request.send as any).species, 'Dog');
-        response$.subscribe(function(response) {
+        response$.subscribe(function(response: any) {
           assert.strictEqual(response.status, 200);
           assert.strictEqual(response.text, 'added Woof the Dog');
           done();
@@ -183,7 +183,7 @@ export function run(uri: string) {
           response$.request.send as string,
           'name=Woof&species=Dog',
         );
-        response$.subscribe(function(response) {
+        response$.subscribe(function(response: any) {
           assert.strictEqual(response.status, 200);
           assert.strictEqual(response.text, 'added Woof the Dog');
           done();
@@ -251,7 +251,7 @@ export function run(uri: string) {
         assert.strictEqual(response$.request.method, 'GET');
         assert.strictEqual((response$.request.query as any).foo, 102030);
         assert.strictEqual((response$.request.query as any).bar, 'Pub');
-        response$.subscribe(function(response) {
+        response$.subscribe(function(response: any) {
           assert.strictEqual(response.status, 200);
           assert.strictEqual((response.body as any).foo, '102030');
           assert.strictEqual((response.body as any).bar, 'Pub');
@@ -280,7 +280,7 @@ export function run(uri: string) {
       response$$.subscribe(function(response$) {
         assert.strictEqual(response$.request.url, uri + '/delete');
         assert.strictEqual(response$.request.method, 'DELETE');
-        response$.subscribe(function(response) {
+        response$.subscribe(function(response: any) {
           assert.strictEqual(response.status, 200);
           assert.strictEqual((response.body as any).deleted, true);
           done();
@@ -338,7 +338,7 @@ export function run(uri: string) {
           next: () => {
             done('next should not be called');
           },
-          error: err => {
+          error: (err: any) => {
             assert.strictEqual(err.status, 500);
             assert.strictEqual(err.message, 'Internal Server Error');
             assert.strictEqual(err.response.text, 'boom');
@@ -363,7 +363,7 @@ export function run(uri: string) {
         const str$ = sources.HTTP
           .select()
           .mergeAll()
-          .map(res => res.text as string);
+          .map((res: any) => res.text as string);
 
         // Notice HTTP comes before Test here. This is crucial for this test.
         return {
@@ -439,7 +439,7 @@ export function run(uri: string) {
       scopedHTTPSource.select().subscribe(function(response$) {
         assert.strictEqual(typeof response$.request, 'object');
         assert.strictEqual(response$.request.url, uri + '/hello');
-        response$.subscribe(function(response) {
+        response$.subscribe(function(response: any) {
           assert.strictEqual(response.status, 200);
           assert.strictEqual(response.text, 'Hello World');
           done();

--- a/http/test/browser/src/index.ts
+++ b/http/test/browser/src/index.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import * as Rx from 'rxjs';
 import * as Cycle from '@cycle/rxjs-run';
-import {makeHTTPDriver} from '../../../lib/index';
+import {makeHTTPDriver} from '../../../lib/cjs/index';
 import {HTTPSource} from '../../../rxjs-typings';
 import {run as runCommon} from './common';
 

--- a/http/test/node.ts
+++ b/http/test/node.ts
@@ -106,7 +106,7 @@ describe('HTTP Driver in Node.js', function() {
 
     const {sources, run} = Cycle.setup(main, {HTTP: makeHTTPDriver()});
 
-    sources.HTTP.select().mergeAll().subscribe(function(r) {
+    sources.HTTP.select().mergeAll().subscribe(function(r: any) {
       assert.ok(r.request);
       assert.strictEqual((r.request as any)._id, 'petRequest');
       done();
@@ -131,10 +131,10 @@ describe('HTTP Driver in Node.js', function() {
     const {sources, run} = Cycle.setup(main, {HTTP: makeHTTPDriver()});
 
     sources.HTTP.select().mergeAll().subscribe({
-      next: function(r) {
+      next: function(r: any) {
         done('next() should not be called');
       },
-      error: function(err) {
+      error: function(err: any) {
         assert.strictEqual(err.code, 'ECONNREFUSED');
         assert.strictEqual(err.port, 9999);
         done();
@@ -160,12 +160,12 @@ describe('HTTP Driver in Node.js', function() {
     const {sources, run} = Cycle.setup(main, {HTTP: makeHTTPDriver()});
 
     sources.HTTP.select().mergeAll().subscribe({
-      next: function(r) {
+      next: function(r: any) {
         assert.ok(r.request);
         assert.strictEqual(r.status, 404);
         done();
       },
-      error: function(err) {
+      error: function(err: any) {
         done('error() should not be called');
       },
     });

--- a/http/test/node.ts
+++ b/http/test/node.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import * as Rx from 'rxjs';
 import * as Cycle from '@cycle/rxjs-run';
-import {makeHTTPDriver} from '../lib/index';
+import {makeHTTPDriver} from '../lib/cjs/index';
 import {HTTPSource} from '../rxjs-typings';
 import {run as runCommon} from './browser/src/common';
 import {globalSandbox} from './support/global';
@@ -152,7 +152,7 @@ describe('HTTP Driver in Node.js', function() {
         HTTP: Rx.Observable.of({
           url: uri + '/not-found-url',
           method: 'GET',
-          ok: (res: any) => (res.status === 404),
+          ok: (res: any) => res.status === 404,
         }),
       };
     }

--- a/isolate/package.json
+++ b/isolate/package.json
@@ -26,10 +26,10 @@
     "dataflow",
     "virtual-dom"
   ],
-  "main": "lib/index.js",
+  "main": "lib/cjs/index.js",
   "module": "lib/es6/index.js",
-  "typings": "lib/index.d.ts",
-  "types": "lib/index.d.ts",
+  "typings": "lib/cjs/index.d.ts",
+  "types": "lib/cjs/index.d.ts",
   "dependencies": {},
   "devDependencies": {
     "@types/mocha": "2.2.x",

--- a/isolate/test/index.ts
+++ b/isolate/test/index.ts
@@ -1,7 +1,7 @@
 import 'mocha';
 import * as assert from 'assert';
 import * as Rx from 'rxjs';
-import isolate from '../lib/index';
+import isolate from '../lib/cjs/index';
 import * as sinon from 'sinon';
 
 describe('isolate', function() {

--- a/most-run/package.json
+++ b/most-run/package.json
@@ -2,10 +2,10 @@
   "name": "@cycle/most-run",
   "version": "7.2.0",
   "description": "The Cycle run() function to be used with most.js",
-  "main": "lib/index.js",
+  "main": "lib/cjs/index.js",
   "module": "lib/es6/index.js",
-  "typings": "lib/index.d.ts",
-  "types": "lib/index.d.ts",
+  "typings": "lib/cjs/index.d.ts",
+  "types": "lib/cjs/index.d.ts",
   "repository": "https://github.com/cyclejs/cyclejs/tree/master/most-run",
   "contributors": [
     {

--- a/most-run/test/index.ts
+++ b/most-run/test/index.ts
@@ -1,7 +1,7 @@
 import 'mocha';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import {run, setup} from '../lib';
+import {run, setup} from '../lib/cjs/index';
 import * as most from 'most';
 import {Stream} from 'most';
 import xs from 'xstream';

--- a/run/package.json
+++ b/run/package.json
@@ -25,10 +25,10 @@
     "mvi",
     "virtual-dom"
   ],
-  "main": "lib/index.js",
+  "main": "lib/cjs/index.js",
   "module": "lib/es6/index.js",
-  "typings": "lib/index.d.ts",
-  "types": "lib/index.d.ts",
+  "typings": "lib/cjs/index.d.ts",
+  "types": "lib/cjs/index.d.ts",
   "dependencies": {
     "xstream": "10.x || 11.x"
   },
@@ -49,7 +49,8 @@
     "test": "npm run mocha",
     "test-ci": "npm run test",
     "browserify": "../node_modules/.bin/browserify lib/index.js --global-transform=browserify-shim --standalone Cycle --exclude xstream -o dist/cycle-run.js",
-    "minify": "node ../.scripts/minify.js dist/cycle-run.js dist/cycle-run.min.js"
+    "minify": "node ../.scripts/minify.js dist/cycle-run.js dist/cycle-run.min.js",
+    "postlib": "cp lib/cjs/adapt.* lib/"
   },
   "publishConfig": {
     "access": "public"

--- a/run/src/adapt.ts
+++ b/run/src/adapt.ts
@@ -3,20 +3,18 @@ import {Stream} from 'xstream';
 declare var window: any;
 
 function getGlobal(): any {
-  let globalObject: any;
+  let globalObj: any;
   if (typeof window !== 'undefined') {
-    globalObject = window;
+    globalObj = window;
   } else if (typeof global !== 'undefined') {
-    globalObject = global;
+    globalObj = global;
   } else {
-    globalObject = this;
+    globalObj = this;
   }
-
-  globalObject.Cyclejs = globalObject.Cyclejs || {};
-  globalObject.Cyclejs.adaptStream =
-    globalObject.Cyclejs.adaptStream || ((x => x) as AdaptStream);
-
-  return globalObject;
+  globalObj.Cyclejs = globalObj.Cyclejs || {};
+  globalObj = globalObj.Cyclejs;
+  globalObj.adaptStream = globalObj.adaptStream || ((x => x) as AdaptStream);
+  return globalObj;
 }
 
 export interface AdaptStream {
@@ -24,9 +22,9 @@ export interface AdaptStream {
 }
 
 export function setAdapt(f: AdaptStream): void {
-  getGlobal().Cyclejs.adaptStream = f;
+  getGlobal().adaptStream = f;
 }
 
 export function adapt(stream: Stream<any>): any {
-  return getGlobal().Cyclejs.adaptStream(stream);
+  return getGlobal().adaptStream(stream);
 }

--- a/run/src/adapt.ts
+++ b/run/src/adapt.ts
@@ -1,15 +1,32 @@
 import {Stream} from 'xstream';
 
+declare var window: any;
+
+function getGlobal(): any {
+  let globalObject: any;
+  if (typeof window !== 'undefined') {
+    globalObject = window;
+  } else if (typeof global !== 'undefined') {
+    globalObject = global;
+  } else {
+    globalObject = this;
+  }
+
+  globalObject.Cyclejs = globalObject.Cyclejs || {};
+  globalObject.Cyclejs.adaptStream =
+    globalObject.Cyclejs.adaptStream || ((x => x) as AdaptStream);
+
+  return globalObject;
+}
+
 export interface AdaptStream {
   (s: Stream<any>): any;
 }
 
-let adaptStream: AdaptStream = x => x;
-
 export function setAdapt(f: AdaptStream): void {
-  adaptStream = f;
+  getGlobal().Cyclejs.adaptStream = f;
 }
 
 export function adapt(stream: Stream<any>): any {
-  return adaptStream(stream);
+  return getGlobal().Cyclejs.adaptStream(stream);
 }

--- a/run/test/index.ts
+++ b/run/test/index.ts
@@ -1,7 +1,7 @@
 import 'mocha';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import {run, setup, Sources, Sinks, Driver} from '../lib';
+import {run, setup, Sources, Sinks, Driver} from '../lib/cjs/index';
 import {setAdapt} from '../lib/adapt';
 import xs, {Stream} from 'xstream';
 import concat from 'xstream/extra/concat';

--- a/rxjs-run/package.json
+++ b/rxjs-run/package.json
@@ -25,10 +25,10 @@
     "mvi",
     "virtual-dom"
   ],
-  "main": "lib/index.js",
+  "main": "lib/cjs/index.js",
   "module": "lib/es6/index.js",
-  "typings": "lib/index.d.ts",
-  "types": "lib/index.d.ts",
+  "typings": "lib/cjs/index.d.ts",
+  "types": "lib/cjs/index.d.ts",
   "dependencies": {
     "@cycle/run": "3.x"
   },

--- a/rxjs-run/test/index.ts
+++ b/rxjs-run/test/index.ts
@@ -1,7 +1,7 @@
 import 'mocha';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import {run, setup} from '../lib';
+import {run, setup} from '../lib/cjs/index';
 import xs, {Stream} from 'xstream';
 import * as Rx from 'rxjs';
 import {Observable} from 'rxjs';

--- a/time/.markdown-doctest-setup.js
+++ b/time/.markdown-doctest-setup.js
@@ -1,4 +1,4 @@
-const timeDriver = require('./lib/');
+const timeDriver = require('./lib/cjs/');
 const xs = require('xstream').default;
 const dom = require('@cycle/dom');
 const most = require('most');

--- a/time/package.json
+++ b/time/package.json
@@ -7,10 +7,10 @@
   "bugs": "https://github.com/cyclejs/cyclejs/issues",
   "repository": "https://github.com/cyclejs/cyclejs/tree/master/time",
   "author": "Nick Johnstone",
-  "main": "lib/index.js",
+  "main": "lib/cjs/index.js",
   "module": "lib/es6/index.js",
-  "typings": "lib/index.d.ts",
-  "types": "lib/index.d.ts",
+  "typings": "lib/cjs/index.d.ts",
+  "types": "lib/cjs/index.d.ts",
   "dependencies": {
     "@cycle/run": "3.x",
     "combine-errors": "3.0.x",


### PR DESCRIPTION
ISSUES CLOSED: #694

- [ ] I added new tests for the issue I fixed/built
- [x] I ran `make test FOO` for the package FOO I'm modifying
- [x] I used `make commit` instead of `git commit`
