### PR TITLE
fix(time): ignore node.js specific modules in React Native

### DIFF
--- a/time/package.json
+++ b/time/package.json
@@ -46,6 +46,9 @@
   "browserify-shim": {
     "xstream": "global:xstream"
   },
+  "react-native": {
+    "variable-diff": false
+  },
   "scripts": {
     "start": "../node_modules/.bin/budo -d example example/index.ts:index.js --live -- -p tsify",
     "test-watch": "../node_modules/.bin/mocha 'test/**/*.ts' --compilers ts:ts-node/register --watch -R min",


### PR DESCRIPTION
I'm using cycle/time in a demo React Native app, and noticed that it won't run because `chalk` (used by `variable-diff`) expects a node.js environment. This PR ignores node.js-specific modules like that one.