### PR TITLE
fix(dom): make DOMSource.elements() monomorphic

### DIFF
--- a/dom/src/BodyDOMSource.ts
+++ b/dom/src/BodyDOMSource.ts
@@ -7,12 +7,19 @@ import {fromEvent} from './fromEvent';
 export class BodyDOMSource implements DOMSource {
   constructor(private _name: string) {}
 
-  public select(selector: string): DOMSource {
+  public select(selector: string): BodyDOMSource {
     // This functionality is still undefined/undecided.
     return this;
   }
 
-  public elements(): MemoryStream<HTMLBodyElement> {
+  public elements(): MemoryStream<Array<HTMLBodyElement>> {
+    const out: DevToolEnabledSource &
+      MemoryStream<Array<HTMLBodyElement>> = adapt(xs.of([document.body]));
+    out._isCycleSource = this._name;
+    return out;
+  }
+
+  public element(): MemoryStream<HTMLBodyElement> {
     const out: DevToolEnabledSource & MemoryStream<HTMLBodyElement> = adapt(
       xs.of(document.body),
     );

--- a/dom/src/DOMSource.ts
+++ b/dom/src/DOMSource.ts
@@ -7,7 +7,10 @@ export interface EventsFnOptions {
 
 export interface DOMSource {
   select(selector: string): DOMSource;
-  elements(): MemoryStream<Document | Element | Array<Element> | string>;
+  elements(): MemoryStream<
+    Array<Document> | Array<HTMLBodyElement> | Array<Element> | string
+  >;
+  element(): MemoryStream<Document | HTMLBodyElement | Element>;
   events<K extends keyof HTMLElementEventMap>(
     eventType: K,
     options?: EventsFnOptions,

--- a/dom/src/DocumentDOMSource.ts
+++ b/dom/src/DocumentDOMSource.ts
@@ -7,12 +7,20 @@ import {fromEvent} from './fromEvent';
 export class DocumentDOMSource implements DOMSource {
   constructor(private _name: string) {}
 
-  public select(selector: string): DOMSource {
+  public select(selector: string): DocumentDOMSource {
     // This functionality is still undefined/undecided.
     return this;
   }
 
-  public elements(): MemoryStream<Document> {
+  public elements(): MemoryStream<Array<Document>> {
+    const out: DevToolEnabledSource & MemoryStream<Array<Document>> = adapt(
+      xs.of([document]),
+    );
+    out._isCycleSource = this._name;
+    return out;
+  }
+
+  public element(): MemoryStream<Document> {
     const out: DevToolEnabledSource & MemoryStream<Document> = adapt(
       xs.of(document),
     );

--- a/dom/src/ElementFinder.ts
+++ b/dom/src/ElementFinder.ts
@@ -13,11 +13,11 @@ export class ElementFinder {
     public isolateModule: IsolateModule,
   ) {}
 
-  public call(rootElement: Element): Element | Array<Element> {
+  public call(rootElement: Element): Array<Element> {
     const namespace = this.namespace;
     const selector = getSelectors(namespace);
     if (!selector) {
-      return rootElement;
+      return [rootElement];
     }
 
     const fullScope = getFullScope(namespace);

--- a/dom/src/index.ts
+++ b/dom/src/index.ts
@@ -11,10 +11,12 @@ export {MainDOMSource} from './MainDOMSource';
  * Snabbdom "VNode" objects. The output of this driver is a "DOMSource": a
  * collection of Observables queried with the methods `select()` and `events()`.
  *
- * `DOMSource.select(selector)` returns a new DOMSource with scope restricted to
- * the element(s) that matches the CSS `selector` given.
+ * **`DOMSource.select(selector)`** returns a new DOMSource with scope
+ * restricted to the element(s) that matches the CSS `selector` given. To select
+ * the page's `document`, use `.select('document')`. To select the container
+ * element for this app, use `.select(':root')`.
  *
- * `DOMSource.events(eventType, options)` returns a stream of events of
+ * **`DOMSource.events(eventType, options)`** returns a stream of events of
  * `eventType` happening on the elements that match the current DOMSource. The
  * event object contains the `ownerTarget` property that behaves exactly like
  * `currentTarget`. The reason for this is that some browsers doesn't allow
@@ -27,12 +29,17 @@ export {MainDOMSource} from './MainDOMSource';
  * https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener
  * about the `useCapture` and its purpose.
  * The other option is `preventDefault` that is set to false by default.
- * If set to true, the driver will automatically call `preventDefault()` on every event.
+ * If set to true, the driver will automatically call `preventDefault()` on
+ * every event.
  *
- * `DOMSource.elements()` returns a stream of the DOM element(s) matched by the
- * selectors in the DOMSource. Also, `DOMSource.select(':root').elements()`
- * returns a stream of DOM element corresponding to the root (or container) of
- * the app on the DOM.
+ * **`DOMSource.elements()`** returns a stream of arrays containing the DOM
+ * elements that match the selectors in the DOMSource (e.g. from previous
+ * `select(x)` calls).
+ *
+ * **`DOMSource.element()`** returns a stream of DOM elements. Notice that this
+ * is the singular version of `.elements()`, so the stream will emit an element,
+ * not an array. If there is no element that matches the selected DOMSource,
+ * then the returned stream will not emit anything.
  *
  * @param {(String|HTMLElement)} container the DOM selector for the element
  * (or the element itself) to contain the rendering of the VTrees.
@@ -40,8 +47,6 @@ export {MainDOMSource} from './MainDOMSource';
  *
  *   - `modules: array` overrides `@cycle/dom`'s default Snabbdom modules as
  *     as defined in [`src/modules.ts`](./src/modules.ts).
- *   - `transposition: boolean` enables/disables transposition of inner streams
- *     in the virtual DOM tree.
  * @return {Function} the DOM driver function. The function expects a stream of
  * VNode as input, and outputs the DOMSource object.
  * @function makeDOMDriver

--- a/dom/src/mockDOMSource.ts
+++ b/dom/src/mockDOMSource.ts
@@ -28,6 +28,16 @@ export class MockedDOMSource implements DOMSource {
     return out;
   }
 
+  public element(): any {
+    const output$: MemoryStream<Element> = this.elements()
+      .filter((arr: Array<any>) => arr.length > 0)
+      .map((arr: Array<any>) => arr[0])
+      .remember();
+    const out: DevToolEnabledSource & MemoryStream<Element> = adapt(output$);
+    out._isCycleSource = 'MockedDOM';
+    return out;
+  }
+
   public events(eventType: string, options?: EventsFnOptions): any {
     const streamForEventType = this._mockConfig[eventType] as any;
     const out: DevToolEnabledSource & FantasyObservable = adapt(

--- a/dom/test/browser/src/dom-driver.ts
+++ b/dom/test/browser/src/dom-driver.ts
@@ -130,7 +130,7 @@ describe('DOM Driver', function() {
     let dispose: any;
     let hasDisposed = false;
     let assertionOngoing = false;
-    sources.DOM.select(':root').elements().drop(1).addListener({
+    sources.DOM.select(':root').element().drop(1).addListener({
       next: (root: Element) => {
         const selectEl = root.querySelector('.target') as Element;
         if (!selectEl && assertionOngoing && hasDisposed) {

--- a/dom/test/browser/src/elements.ts
+++ b/dom/test/browser/src/elements.ts
@@ -1,0 +1,146 @@
+import * as simulant from 'simulant';
+import * as assert from 'assert';
+import isolate from '@cycle/isolate';
+import xs, {Stream, MemoryStream} from 'xstream';
+import delay from 'xstream/extra/delay';
+import concat from 'xstream/extra/concat';
+import {setup, run} from '@cycle/run';
+import {
+  svg,
+  div,
+  span,
+  h2,
+  h3,
+  h4,
+  p,
+  makeDOMDriver,
+  MainDOMSource,
+  VNode,
+} from '../../../lib';
+
+function createRenderTarget(id: string | null = null) {
+  const element = document.createElement('div');
+  element.className = 'cycletest';
+  if (id) {
+    element.id = id;
+  }
+  document.body.appendChild(element);
+  return element;
+}
+
+describe('DOMSource.elements()', function() {
+  it('should return a stream of documents when querying "document"', function(
+    done,
+  ) {
+    function app(sources: {DOM: MainDOMSource}) {
+      return {
+        DOM: xs.of(div('.top-most', [p('Foo'), span('Bar')])),
+      };
+    }
+
+    const {sinks, sources, run} = setup(app, {
+      DOM: makeDOMDriver(createRenderTarget()),
+    });
+
+    function isDocument(element: any): element is Document {
+      return 'body' in element && 'head' in element;
+    }
+
+    let dispose: any;
+    sources.DOM.select('document').element().take(1).addListener({
+      next: root => {
+        assert(root.body !== undefined); //Check type inference
+        assert(isDocument(root));
+        setTimeout(() => {
+          dispose();
+          done();
+        });
+      },
+    });
+    dispose = run();
+  });
+
+  it('should return a stream of bodies when querying "body"', function(done) {
+    function app(sources: {DOM: MainDOMSource}) {
+      return {
+        DOM: xs.of(div('.top-most', [p('Foo'), span('Bar')])),
+      };
+    }
+
+    const {sinks, sources, run} = setup(app, {
+      DOM: makeDOMDriver(createRenderTarget()),
+    });
+
+    function isBody(element: any): element is HTMLBodyElement {
+      return 'aLink' in element && 'link' in element;
+    }
+
+    let dispose: any;
+    sources.DOM.select('body').element().take(1).addListener({
+      next: root => {
+        assert(root.aLink !== undefined); //Check type inference
+        assert(isBody(root));
+        setTimeout(() => {
+          dispose();
+          done();
+        });
+      },
+    });
+    dispose = run();
+  });
+
+  it('should return a stream of arrays of elements of size 1 when querying ":root"', function(
+    done,
+  ) {
+    function app(sources: {DOM: MainDOMSource}) {
+      return {
+        DOM: xs.of(div('.top-most', [p('Foo'), span('Bar')])),
+      };
+    }
+
+    const {sinks, sources, run} = setup(app, {
+      DOM: makeDOMDriver(createRenderTarget()),
+    });
+
+    let dispose: any;
+    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+      next: root => {
+        assert(root.forEach !== undefined); //Check type inference
+        assert(Array.isArray(root));
+        assert(root.length === 1);
+        setTimeout(() => {
+          dispose();
+          done();
+        });
+      },
+    });
+    dispose = run();
+  });
+
+  it('should return a stream of arrays of elements of size 2 when querying ".some"', function(
+    done,
+  ) {
+    function app(sources: {DOM: MainDOMSource}) {
+      return {
+        DOM: xs.of(div('.top-most', [div('.some'), div('.some')])),
+      };
+    }
+
+    const {sinks, sources, run} = setup(app, {
+      DOM: makeDOMDriver(createRenderTarget()),
+    });
+
+    let dispose: any;
+    sources.DOM.select('.some').elements().drop(1).take(1).addListener({
+      next: (elems: Element[]) => {
+        assert(Array.isArray(elems));
+        assert(elems.length === 2);
+        setTimeout(() => {
+          dispose();
+          done();
+        });
+      },
+    });
+    dispose = run();
+  });
+});

--- a/dom/test/browser/src/events.ts
+++ b/dom/test/browser/src/events.ts
@@ -81,7 +81,7 @@ describe('DOMSource.events()', function() {
       },
     });
     // Make assertions
-    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+    sources.DOM.select(':root').element().drop(1).take(1).addListener({
       next: function(root: Element) {
         const myElement = root.querySelector('.myelementclass') as HTMLElement;
         assert.notStrictEqual(myElement, null);
@@ -195,7 +195,7 @@ describe('DOMSource.events()', function() {
       },
     });
 
-    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+    sources.DOM.select(':root').element().drop(1).take(1).addListener({
       next: (root: Element) => {
         const myElement = root.querySelector('.myelementclass') as HTMLElement;
         assert.notStrictEqual(myElement, null);
@@ -233,7 +233,7 @@ describe('DOMSource.events()', function() {
       },
     });
 
-    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+    sources.DOM.select(':root').element().drop(1).take(1).addListener({
       next: (root: Element) => {
         const myElement = root.querySelector('#myElementId') as HTMLElement;
         assert.notStrictEqual(myElement, null);
@@ -269,7 +269,7 @@ describe('DOMSource.events()', function() {
       },
     });
 
-    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+    sources.DOM.select(':root').element().drop(1).take(1).addListener({
       next: (root: Element) => {
         const myElement = root.querySelector('.myelementclass') as HTMLElement;
         assert.notStrictEqual(myElement, null);
@@ -312,7 +312,7 @@ describe('DOMSource.events()', function() {
       },
     });
 
-    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+    sources.DOM.select(':root').element().drop(1).take(1).addListener({
       next: (root: Element) => {
         const wrongElement = root.querySelector('.bar') as HTMLElement;
         const correctElement = root.querySelector('.foo .bar') as HTMLElement;
@@ -372,7 +372,7 @@ describe('DOMSource.events()', function() {
         },
       });
 
-    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+    sources.DOM.select(':root').element().drop(1).take(1).addListener({
       next: (root: Element) => {
         const firstElem = root.querySelector('.first') as HTMLElement;
         const secondElem = root.querySelector('.second') as HTMLElement;
@@ -415,7 +415,7 @@ describe('DOMSource.events()', function() {
       },
     });
 
-    sources.DOM.select(':root').elements().drop(3).take(1).addListener({
+    sources.DOM.select(':root').element().drop(3).take(1).addListener({
       next: (root: Element) => {
         const myElement = root.querySelector('.blosh') as HTMLElement;
         assert.notStrictEqual(myElement, null);
@@ -467,7 +467,7 @@ describe('DOMSource.events()', function() {
           },
         });
 
-      sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+      sources.DOM.select(':root').element().drop(1).take(1).addListener({
         next: (root: Element) => {
           const clickable = root.querySelector('.clickable') as HTMLElement;
           setTimeout(() => clickable.click(), 80);
@@ -516,7 +516,7 @@ describe('DOMSource.events()', function() {
           },
         });
 
-      sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+      sources.DOM.select(':root').element().drop(1).take(1).addListener({
         next: (root: Element) => {
           const clickable = root.querySelector('.clickable') as HTMLElement;
           setTimeout(() => clickable.click(), 80);
@@ -566,7 +566,7 @@ describe('DOMSource.events()', function() {
     });
 
     // Make assertions
-    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+    sources.DOM.select(':root').element().drop(1).take(1).addListener({
       next: (root: Element) => {
         const child = root.querySelector('.child') as HTMLElement;
         assert.notStrictEqual(child, null);
@@ -604,7 +604,7 @@ describe('DOMSource.events()', function() {
       },
     });
 
-    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+    sources.DOM.select(':root').element().drop(1).take(1).addListener({
       next: (root: Element) => {
         const form = root.querySelector('.form') as HTMLFormElement;
         setTimeout(() => form.reset());
@@ -669,7 +669,7 @@ describe('DOMSource.events()', function() {
         },
       });
 
-    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+    sources.DOM.select(':root').element().drop(1).take(1).addListener({
       next: (root: Element) => {
         const clickable = root.querySelector('.clickable') as HTMLElement;
         setTimeout(() => click(clickable));
@@ -709,7 +709,7 @@ describe('DOMSource.events()', function() {
           },
         });
 
-      sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+      sources.DOM.select(':root').element().drop(1).take(1).addListener({
         next: (root: Element) => {
           const correct = root.querySelector('.correct') as HTMLElement;
           const wrong = root.querySelector('.wrong') as HTMLElement;
@@ -752,7 +752,7 @@ describe('DOMSource.events()', function() {
         },
       });
 
-      sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+      sources.DOM.select(':root').element().drop(1).take(1).addListener({
         next: (root: Element) => {
           const correct = root.querySelector('.correct') as HTMLElement;
           const wrong = root.querySelector('.wrong') as HTMLElement;
@@ -800,7 +800,7 @@ describe('DOMSource.events()', function() {
         },
       });
 
-    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+    sources.DOM.select(':root').element().drop(1).take(1).addListener({
       next: (root: Element) => {
         const form = root.querySelector('.form') as HTMLFormElement;
         setTimeout(() => form.reset());
@@ -896,7 +896,7 @@ describe('DOMSource.events()', function() {
       },
     });
 
-    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+    sources.DOM.select(':root').element().drop(1).take(1).addListener({
       next: (root: Element) => {
         const clickable = root.querySelector('.item') as HTMLElement;
         setTimeout(() => switchSubject.shamefullySendNext(null));
@@ -935,7 +935,7 @@ describe('DOMSource.events()', function() {
         },
       });
 
-    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+    sources.DOM.select(':root').element().drop(1).take(1).addListener({
       next: (root: Element) => {
         const button = root.querySelector('.button') as HTMLButtonElement;
         setTimeout(() => button.click());
@@ -971,7 +971,7 @@ describe('DOMSource.events()', function() {
         },
       });
 
-    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+    sources.DOM.select(':root').element().drop(1).take(1).addListener({
       next: (root: Element) => {
         const button = root.querySelector('.button') as HTMLButtonElement;
         setTimeout(() => button.click());
@@ -1007,7 +1007,7 @@ describe('DOMSource.events()', function() {
         },
       });
 
-    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+    sources.DOM.select(':root').element().drop(1).take(1).addListener({
       next: (root: Element) => {
         const button = root.querySelector('.button') as HTMLButtonElement;
         setTimeout(() => button.click());
@@ -1045,7 +1045,7 @@ describe('DOMSource.events()', function() {
         },
       });
 
-    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+    sources.DOM.select(':root').element().drop(1).take(1).addListener({
       next: (root: Element) => {
         const button = root.querySelector('.button') as HTMLButtonElement;
         setTimeout(() => button.click());
@@ -1081,7 +1081,7 @@ describe('DOMSource.events()', function() {
         },
       });
 
-    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+    sources.DOM.select(':root').element().drop(1).take(1).addListener({
       next: (root: Element) => {
         const button = root.querySelector('.button') as HTMLButtonElement;
         setTimeout(() => button.click());
@@ -1117,7 +1117,7 @@ describe('DOMSource.events()', function() {
         },
       });
 
-    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+    sources.DOM.select(':root').element().drop(1).take(1).addListener({
       next: (root: Element) => {
         const button = root.querySelector('.button') as HTMLButtonElement;
         setTimeout(() => button.click());
@@ -1155,7 +1155,7 @@ describe('DOMSource.events()', function() {
         },
       });
 
-    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+    sources.DOM.select(':root').element().drop(1).take(1).addListener({
       next: (root: Element) => {
         const button = root.querySelector('.button') as HTMLButtonElement;
         setTimeout(() => button.click());

--- a/dom/test/browser/src/index.ts
+++ b/dom/test/browser/src/index.ts
@@ -2,4 +2,5 @@ import './dom-driver';
 import './render';
 import './events';
 import './select';
+import './elements';
 import './isolation';

--- a/dom/test/browser/src/isolation.ts
+++ b/dom/test/browser/src/isolation.ts
@@ -403,7 +403,9 @@ describe('isolation', function() {
   it('should allow using elements() in an isolated main() fn', function(done) {
     function main(sources) {
       const elem$ = sources.DOM.select(':root').elements();
-      const vnode$ = elem$.map(elem => h('div.bar', 'left=' + elem.offsetLeft));
+      const vnode$ = elem$.map(elem =>
+        h('div.bar', 'left=' + elem[0].offsetLeft),
+      );
       return {
         DOM: vnode$,
       };
@@ -413,9 +415,9 @@ describe('isolation', function() {
       DOM: makeDOMDriver(createRenderTarget()),
     });
 
-    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
-      next: (rootElement: Element) => {
-        const barElem = rootElement.querySelector('.bar') as Element;
+    sources.DOM.select(':root').element().drop(1).take(1).addListener({
+      next: (root: Element) => {
+        const barElem = root.querySelector('.bar') as Element;
         assert.notStrictEqual(barElem, null);
         assert.notStrictEqual(typeof barElem, 'undefined');
         assert.strictEqual(barElem.tagName, 'DIV');
@@ -561,7 +563,7 @@ describe('isolation', function() {
       },
     });
 
-    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+    sources.DOM.select(':root').element().drop(1).take(1).addListener({
       next: (root: Element) => {
         const frameFoo = root.querySelector('.foo.frame') as HTMLElement;
         const monalisaFoo = root.querySelector('.foo.monalisa') as HTMLElement;
@@ -981,7 +983,7 @@ describe('isolation', function() {
     });
 
     let dispose: any;
-    sources.DOM.select(':root').elements().drop(2).take(1).addListener({
+    sources.DOM.select(':root').element().drop(2).take(1).addListener({
       next: (root: Element) => {
         const parentEl = root.querySelector('.parent') as HTMLElement;
         const foo = parentEl.querySelectorAll('.foo')[1] as HTMLElement;
@@ -1038,14 +1040,14 @@ describe('isolation', function() {
     });
 
     let dispose: any;
-    sources.DOM.select(':root').elements().drop(1).take(3).addListener({
-      next: (root: any) => {
+    sources.DOM.select(':root').element().drop(1).take(3).addListener({
+      next: (root: Element) => {
         setTimeout(() => {
           const foo = root.querySelector('.foo');
           if (!foo) {
             return;
           }
-          foo.click();
+          (foo as any).click();
         }, 0);
       },
     });
@@ -1090,14 +1092,14 @@ describe('isolation', function() {
     });
 
     let dispose: any;
-    sources.DOM.select(':root').elements().drop(1).take(4).addListener({
-      next: (root: any) => {
+    sources.DOM.select(':root').element().drop(1).take(4).addListener({
+      next: (root: Element) => {
         setTimeout(() => {
           const foo = root.querySelector('.foo');
           if (!foo) {
             return;
           }
-          foo.click();
+          (foo as any).click();
         }, 0);
       },
     });
@@ -1149,14 +1151,14 @@ describe('isolation', function() {
     });
 
     let dispose: any;
-    sources.DOM.select(':root').elements().drop(1).take(4).addListener({
-      next: (root: any) => {
+    sources.DOM.select(':root').element().drop(1).take(4).addListener({
+      next: (root: Element) => {
         setTimeout(() => {
           const foo = root.querySelector('.foo');
           if (!foo) {
             return;
           }
-          foo.click();
+          (foo as any).click();
         }, 0);
       },
     });
@@ -1199,7 +1201,7 @@ describe('isolation', function() {
         DOM: makeDOMDriver(createRenderTarget()),
       });
 
-      sources.DOM.elements().drop(1).take(1).addListener({
+      sources.DOM.element().drop(1).take(1).addListener({
         next: (root: Element) => {
           const element = root.querySelector('.btn') as HTMLElement;
           assert.notStrictEqual(element, null);
@@ -1243,7 +1245,7 @@ describe('isolation', function() {
         DOM: makeDOMDriver(createRenderTarget()),
       });
 
-      sources.DOM.elements().drop(1).take(1).addListener({
+      sources.DOM.element().drop(1).take(1).addListener({
         next: (root: Element) => {
           const element = root.querySelector('.btn') as HTMLElement;
           assert.notStrictEqual(element, null);
@@ -1287,7 +1289,7 @@ describe('isolation', function() {
         DOM: makeDOMDriver(createRenderTarget()),
       });
 
-      sources.DOM.elements().drop(1).take(1).addListener({
+      sources.DOM.element().drop(1).take(1).addListener({
         next: (root: Element) => {
           const element = root.querySelector('.btn') as HTMLElement;
           assert.notStrictEqual(element, null);
@@ -1331,7 +1333,7 @@ describe('isolation', function() {
         DOM: makeDOMDriver(createRenderTarget()),
       });
 
-      sources.DOM.elements().drop(1).take(1).addListener({
+      sources.DOM.element().drop(1).take(1).addListener({
         next: (root: Element) => {
           const element = root.querySelector('.btn') as HTMLElement;
           assert.notStrictEqual(element, null);
@@ -1388,7 +1390,7 @@ describe('isolation', function() {
       });
 
       let dispose: any;
-      sources.DOM.elements().drop(1).take(1).addListener({
+      sources.DOM.element().drop(1).take(1).addListener({
         next: (root: Element) => {
           const components = root.querySelectorAll('.btn');
           assert.strictEqual(components.length, 2);
@@ -1435,7 +1437,7 @@ describe('isolation', function() {
     });
 
     let dispose: any;
-    sources.DOM.elements().drop(1).take(1).addListener({
+    sources.DOM.element().drop(1).take(1).addListener({
       next: (root: Element) => {
         const parentEl = root.querySelector('.parent') as Element;
         assert.strictEqual(parentEl.childNodes.length, 2);
@@ -1445,7 +1447,7 @@ describe('isolation', function() {
         assert.strictEqual(parentEl.children[1].textContent, 'part of parent');
       },
     });
-    sources.DOM.elements().drop(2).take(1).addListener({
+    sources.DOM.element().drop(2).take(1).addListener({
       next: (root: Element) => {
         const parentEl = root.querySelector('.parent') as Element;
         assert.strictEqual(parentEl.childNodes.length, 1);
@@ -1491,7 +1493,7 @@ describe('isolation', function() {
     });
 
     let dispose: any;
-    sources.DOM.elements().drop(1).take(1).addListener({
+    sources.DOM.element().drop(1).take(1).addListener({
       next: (root: Element) => {
         const buttons = root.querySelectorAll('.btn');
         assert.strictEqual(buttons.length, 4);
@@ -1564,7 +1566,7 @@ describe('isolation', function() {
       },
     });
 
-    sources.DOM.select(':root').elements().drop(1).addListener({
+    sources.DOM.select(':root').element().drop(1).addListener({
       next: function(root: Element) {
         const button = root.querySelector('button.click-me') as HTMLElement;
         button.click();

--- a/dom/test/browser/src/render.tsx
+++ b/dom/test/browser/src/render.tsx
@@ -95,7 +95,7 @@ describe('DOM Rendering', function () {
       });
 
       let dispose: any;
-      sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+      sources.DOM.select(':root').element().drop(1).take(1).addListener({
         next: (root: Element) => {
           const elem = root.querySelector('.my-class') as HTMLElement;
           assert.notStrictEqual(elem, null);
@@ -130,7 +130,7 @@ describe('DOM Rendering', function () {
     });
 
     let dispose: any;
-    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+    sources.DOM.select(':root').element().drop(1).take(1).addListener({
       next: (root: Element) => {
         const selectEl = root.querySelector('.my-class') as HTMLElement;
         assert.notStrictEqual(selectEl, null);
@@ -163,7 +163,7 @@ describe('DOM Rendering', function () {
     });
 
     let dispose: any;
-    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+    sources.DOM.select(':root').element().drop(1).take(1).addListener({
       next: (root: Element) => {
         const selectEl = root.querySelector('.my-class') as HTMLElement;
         assert.notStrictEqual(selectEl, null);
@@ -196,7 +196,7 @@ describe('DOM Rendering', function () {
     });
 
     let dispose: any;
-    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+    sources.DOM.select(':root').element().drop(1).take(1).addListener({
       next: (root: Element) => {
         const selectEl = root.querySelector('.my-class') as HTMLSelectElement;
         assert.notStrictEqual(selectEl, null);
@@ -241,7 +241,7 @@ describe('DOM Rendering', function () {
     });
 
     let dispose: any;
-    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+    sources.DOM.select(':root').element().drop(1).take(1).addListener({
       next: (root: Element) => {
         assert.strictEqual(root.childNodes.length, 1);
         const selectEl = root.childNodes[0] as HTMLElement;
@@ -283,7 +283,7 @@ describe('DOM Rendering', function () {
     let firstSubscriberRan = false;
     let secondSubscriberRan = false;
 
-    const element$ = sources.DOM.select(':root').elements();
+    const element$ = sources.DOM.select(':root').element();
 
     element$.drop(1).take(1).addListener({
       next: (root: Element) => {
@@ -338,6 +338,25 @@ describe('DOM Rendering', function () {
     done();
   });
 
+  it('should have DevTools flag in element source stream', function (done) {
+    function app(sources: {DOM: MainDOMSource}) {
+      return {
+        DOM: xs.merge(
+          xs.of(h2('.value-over-time', 'Hello test')),
+          xs.never(),
+        ),
+      };
+    }
+
+    const {sinks, sources, run} = setup(app, {
+      DOM: makeDOMDriver(createRenderTarget()),
+    });
+
+    const element$ = sources.DOM.select(':root').element();
+    assert.strictEqual((element$ as any)._isCycleSource, 'DOM');
+    done();
+  });
+
   it('should allow snabbdom Thunks in the VTree', function (done) {
     function renderThunk(greeting: string) {
       return h4('Constantly ' + greeting);
@@ -361,7 +380,7 @@ describe('DOM Rendering', function () {
 
     let dispose: any;
     // Assert it
-    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+    sources.DOM.select(':root').element().drop(1).take(1).addListener({
       next: (root: Element) => {
         const h4Elem = root.querySelector('h4') as HTMLElement;
         assert.notStrictEqual(h4Elem, null);
@@ -402,7 +421,7 @@ describe('DOM Rendering', function () {
       let dispose: any;
 
       // Make assertions
-      sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+      sources.DOM.select(':root').element().drop(1).take(1).addListener({
         next: (root: Element) => {
           const embeddedHTML = root.querySelector('p.embedded-text') as HTMLElement;
           assert.strictEqual(embeddedHTML.namespaceURI, 'http://www.w3.org/1999/xhtml');
@@ -448,7 +467,7 @@ describe('DOM Rendering', function () {
 
     let dispose: any;
     // Assert it
-    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+    sources.DOM.select(':root').element().drop(1).take(1).addListener({
       next: (root: Element) => {
         const divParent = root.querySelector('div.parent') as HTMLElement;
         const h4Child = root.querySelector('h4.child3') as HTMLElement;
@@ -475,7 +494,7 @@ describe('DOM Rendering', function () {
     });
 
     let dispose: any;
-    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+    sources.DOM.select(':root').element().drop(1).take(1).addListener({
       next: (root: Element) => {
         const H4 = root.querySelector('h4') as HTMLElement;
         assert.strictEqual(H4.textContent, 'Hello world');
@@ -500,7 +519,7 @@ describe('DOM Rendering', function () {
     });
 
     let dispose: any;
-    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+    sources.DOM.select(':root').element().drop(1).take(1).addListener({
       next: (root: Element) => {
         const divEl = root.querySelector('.my-class') as HTMLElement;
         assert.strictEqual(divEl.textContent, '0');

--- a/dom/test/browser/src/select.ts
+++ b/dom/test/browser/src/select.ts
@@ -41,7 +41,7 @@ describe('DOMSource.select()', function() {
     });
 
     let dispose: any;
-    sources.DOM.select(':root').elements().drop(1).take(1).addListener({
+    sources.DOM.select(':root').element().drop(1).take(1).addListener({
       next: (root: Element) => {
         const classNameRegex = /top\-most/;
         assert.strictEqual(root.tagName, 'DIV');
@@ -78,6 +78,8 @@ describe('DOMSource.select()', function() {
     assert.strictEqual(typeof selection.select, 'function');
     assert.strictEqual(typeof selection.select('h3'), 'object');
     assert.strictEqual(typeof selection.elements, 'function');
+    assert.strictEqual(typeof selection.element(), 'object');
+    assert.strictEqual(typeof selection.element().subscribe, 'function');
     assert.strictEqual(typeof selection.elements(), 'object');
     assert.strictEqual(typeof selection.elements().subscribe, 'function');
     assert.strictEqual(typeof selection.events, 'function');
@@ -258,6 +260,24 @@ describe('DOMSource.select()', function() {
     simulant.fire(document.body, 'click');
   });
 
+  it('should have DevTools flag in BodyDOMSource element() stream', function(
+    done,
+  ) {
+    function app(sources: {DOM: MainDOMSource}) {
+      return {
+        DOM: xs.of(div('hello world')),
+      };
+    }
+
+    const {sinks, sources, run} = setup(app, {
+      DOM: makeDOMDriver(createRenderTarget()),
+    });
+
+    const element$ = sources.DOM.select('body').element();
+    assert.strictEqual((element$ as any)._isCycleSource, 'DOM');
+    done();
+  });
+
   it('should have DevTools flag in BodyDOMSource elements() stream', function(
     done,
   ) {
@@ -291,6 +311,24 @@ describe('DOMSource.select()', function() {
 
     const event$ = sources.DOM.select('body').events('click');
     assert.strictEqual((event$ as any)._isCycleSource, 'DOM');
+    done();
+  });
+
+  it('should have DevTools flag in DocumentDOMSource element() stream', function(
+    done,
+  ) {
+    function app(sources: {DOM: MainDOMSource}) {
+      return {
+        DOM: xs.of(div('hello world')),
+      };
+    }
+
+    const {sinks, sources, run} = setup(app, {
+      DOM: makeDOMDriver(createRenderTarget()),
+    });
+
+    const element$ = sources.DOM.select('document').element();
+    assert.strictEqual((element$ as any)._isCycleSource, 'DOM');
     done();
   });
 


### PR DESCRIPTION
MainDOMSource.elements() now always returns an array of Elements, return types of the other
DOMSources are correctly inferred

ISSUES CLOSED: #677
BREAKING CHANGE: `elements()` now always returns an array of elements if
you pass a selector

<!--
Thank you for your contribution! You're awesome.
To help speed up the process of merging your code, check the following:
-->

- [x] I added new tests for the issue I fixed/built
- [x] I ran `make test FOO` for the package FOO I'm modifying
- [x] I used `make commit` instead of `git commit`
