### PR TITLE
docs(META): add links to source for each package in api reference

### DIFF
--- a/docs/content/api/dom.md
+++ b/docs/content/api/dom.md
@@ -1,4 +1,4 @@
-# Cycle DOM
+# Cycle DOM - [source](https://github.com/cyclejs/cyclejs/tree/master/dom)
 
 A Cycle.js driver to enable interaction with the DOM. The driver is based on [snabbdom](https://github.com/paldepind/snabbdom/) as the Virtual DOM library.
 

--- a/docs/content/api/history.md
+++ b/docs/content/api/history.md
@@ -1,4 +1,4 @@
-# Cycle History
+# Cycle History - [source](https://github.com/cyclejs/cyclejs/tree/master/history)
 
 This is the standard Cycle.js driver for dealing with the History API.
 

--- a/docs/content/api/html.md
+++ b/docs/content/api/html.md
@@ -1,4 +1,4 @@
-# Cycle HTML
+# Cycle HTML - [source](https://github.com/cyclejs/cyclejs/tree/master/html)
 
 A Cycle.js driver to render virtual DOM streams as HTML. This is based on the DOM driver and [snabbdom](https://github.com/paldepind/snabbdom/), and is intended for server-side rendered HTML that mirrors what the DOM driver would render client-side.
 

--- a/docs/content/api/http.md
+++ b/docs/content/api/http.md
@@ -1,4 +1,4 @@
-# Cycle HTTP
+# Cycle HTTP - [source](https://github.com/cyclejs/cyclejs/tree/master/http)
 
 A Driver for making HTTP requests, based on [superagent](https://github.com/visionmedia/superagent).
 

--- a/docs/content/api/isolate.md
+++ b/docs/content/api/isolate.md
@@ -1,4 +1,4 @@
-# Isolate
+# Isolate - [source](https://github.com/cyclejs/cyclejs/tree/master/isolate)
 
 A utility function to make scoped dataflow components in Cycle.js.
 

--- a/docs/content/api/most-run.md
+++ b/docs/content/api/most-run.md
@@ -1,4 +1,4 @@
-# Run() for most.js
+# Run() for most.js - [source](https://github.com/cyclejs/cyclejs/tree/master/most-run)
 
 Cycle.js `run(main, drivers)` function for applications written with most.js (Monadic Streams)
 

--- a/docs/content/api/run.md
+++ b/docs/content/api/run.md
@@ -1,4 +1,4 @@
-# Run() for xstream
+# Run() for xstream - [source](https://github.com/cyclejs/cyclejs/tree/master/run)
 
 Cycle.js `run(main, drivers)` function for applications written with xstream.
 

--- a/docs/content/api/rxjs-run.md
+++ b/docs/content/api/rxjs-run.md
@@ -1,4 +1,4 @@
-# Run() for RxJS
+# Run() for RxJS - [source](https://github.com/cyclejs/cyclejs/tree/master/rxjs-run)
 
 Cycle.js `run(main, drivers)` function for applications written with RxJS version **5**.
 


### PR DESCRIPTION
If this is useful, another option would be to include the source links in the index instead.

- [ ] There exists an issue discussing the need for this PR
- [ ] I added new tests for the issue I fixed or built
- [ ] I ran `make test FOO` for the package FOO I'm modifying
- [X] I used `make commit` instead of `git commit`
