### PR TITLE
fix(history): fix captureClicks listener cleanup

### DIFF
--- a/history/test/browser/common.ts
+++ b/history/test/browser/common.ts
@@ -9,7 +9,9 @@ import {
   makeHistoryDriver,
 } from '../../src';
 import {createMemoryHistory} from 'history';
-import xs from 'xstream';
+import xs, {Stream} from 'xstream';
+import {setup} from '@cycle/run';
+import {setAdapt} from '@cycle/run/lib/adapt';
 
 describe('makeHistoryDriver', () => {
   it('should be a function', () => {
@@ -76,12 +78,14 @@ describe.skip('makeHashHistoryDriver', () => {
 describe('captureClicks', () => {
   it('should allow listening to link clicks and change route', function(done) {
     const historyDriver = makeHistoryDriver();
-    const history$ = captureClicks(historyDriver)(xs.never());
+    const sink = xs.never();
+    const history$ = captureClicks(historyDriver)(sink);
 
     const sub = history$.drop(1).subscribe({
       next: (location: Location) => {
         assert.strictEqual(location.pathname, '/test');
         sub.unsubscribe();
+        sink.shamefullySendComplete();
         done();
       },
       error: err => {},
@@ -90,6 +94,53 @@ describe('captureClicks', () => {
 
     const a = document.createElement('a');
     a.href = '/test';
+    document.body.appendChild(a);
+
+    setTimeout(() => {
+      a.click();
+    });
+  });
+
+  it('should remove click listener when disposed of', function(done) {
+    setAdapt(x => x);
+
+    function main(sources: {history: Stream<Location>}) {
+      return {
+        history: xs.never(),
+      };
+    }
+
+    const {sources: sources1, run: run1} = setup(main, {
+      history: captureClicks(makeHistoryDriver()),
+    });
+    const sub1 = sources1.history.drop(1).subscribe({
+      next: () => done(new Error('should not trigger')),
+      error: err => {},
+      complete: () => {},
+    });
+    const dispose1 = run1();
+    dispose1();
+
+    const {sources: sources2, run: run2} = setup(main, {
+      history: captureClicks(makeHistoryDriver()),
+    });
+    let dispose2 = () => {};
+    const sub2 = sources2.history.drop(1).subscribe({
+      next: (location: Location) => {
+        assert.strictEqual(location.pathname, '/dispose');
+        sub1.unsubscribe();
+        sub2.unsubscribe();
+        dispose2();
+        done();
+      },
+      error: err => done(err),
+      complete: () => {},
+    });
+
+    dispose2 = run2();
+
+    const a = document.createElement('a');
+    a.href = '/dispose';
     document.body.appendChild(a);
 
     setTimeout(() => {


### PR DESCRIPTION
<!--
Thank you for your contribution! You're awesome.
To help speed up the process of merging your code, check the following:
-->

Ensure the document event listener added when using captureClicks
is properly removed when the sink passed to the driver is disposed of

ISSUES CLOSED: #734