### PR TITLE
refactor(history): tests cleanup, remove tests skip

### DIFF
--- a/history/test/browser/common.ts
+++ b/history/test/browser/common.ts
@@ -27,28 +27,27 @@ describe('makeHistoryDriver', () => {
     assert.strictEqual(typeof makeHistoryDriver(history), 'function');
   });
 
-  it('should start emitting the current location', function(done) {
-    const history$ = makeHistoryDriver()(xs.never());
+  it('should start emitting the current location synchronously', function(
+    done,
+  ) {
+    const sink = xs.never();
+    const history$ = makeHistoryDriver()(sink);
 
     const sub = history$.subscribe({
       next: (location: Location) => {
         assert(location.pathname);
         done();
       },
-      error: err => {},
+      error: done,
       complete: () => {},
     });
 
-    setTimeout(() => {
-      sub.unsubscribe();
-    });
+    sub.unsubscribe();
+    sink.shamefullySendComplete();
   });
 });
 
-// This is skipped because somehow, IN LATEST FIREFOX IN WIN10, state is being
-// carried around between tests. Tests work when run separately, but when run
-// all together, something fails.
-describe.skip('makeHashHistoryDriver', () => {
+describe('makeHashHistoryDriver', () => {
   it('should be a function', () => {
     assert.strictEqual(typeof makeHashHistoryDriver, 'function');
   });
@@ -57,21 +56,23 @@ describe.skip('makeHashHistoryDriver', () => {
     assert.strictEqual(typeof makeHashHistoryDriver(), 'function');
   });
 
-  it('should start emitting the current location', function(done) {
-    const history$ = makeHashHistoryDriver()(xs.never());
+  it('should start emitting the current location synchronously', function(
+    done,
+  ) {
+    const sink = xs.never();
+    const history$ = makeHashHistoryDriver()(sink);
 
     const sub = history$.subscribe({
       next: (location: Location) => {
         assert(location.pathname);
         done();
       },
-      error: err => {},
+      error: done,
       complete: () => {},
     });
 
-    setTimeout(() => {
-      sub.unsubscribe();
-    });
+    sub.unsubscribe();
+    sink.shamefullySendComplete();
   });
 });
 
@@ -88,7 +89,7 @@ describe('captureClicks', () => {
         sink.shamefullySendComplete();
         done();
       },
-      error: err => {},
+      error: done,
       complete: () => {},
     });
 
@@ -115,7 +116,7 @@ describe('captureClicks', () => {
     });
     const sub1 = sources1.history.drop(1).subscribe({
       next: () => done(new Error('should not trigger')),
-      error: err => {},
+      error: done,
       complete: () => {},
     });
     const dispose1 = run1();
@@ -133,7 +134,7 @@ describe('captureClicks', () => {
         dispose2();
         done();
       },
-      error: err => done(err),
+      error: done,
       complete: () => {},
     });
 

--- a/history/test/browser/rxjs.ts
+++ b/history/test/browser/rxjs.ts
@@ -8,17 +8,24 @@ import {
   captureClicks,
   makeHistoryDriver,
 } from '../../src';
-import {run, setup} from '@cycle/rxjs-run';
+import {setup} from '@cycle/rxjs-run';
+import {setAdapt} from '@cycle/run/lib/adapt';
 
-import {Observable} from 'rxjs';
+import {Observable, Subscription} from 'rxjs';
 import 'rxjs/add/operator/switchMap';
 
 let dispose = () => {};
+let sub: Subscription | undefined;
 
-// This is skipped because somehow state is being carried around between tests.
-// Tests work when run separately, but when run all together, something fails.
-describe.skip('historyDriver - RxJS', () => {
+describe('historyDriver - RxJS', () => {
   beforeEach(function() {
+    setAdapt(stream => Observable.from(stream));
+  });
+
+  afterEach(function() {
+    if (sub) {
+      sub.unsubscribe();
+    }
     dispose();
   });
 
@@ -43,7 +50,7 @@ describe.skip('historyDriver - RxJS', () => {
 
     const {sources, run} = setup(main, {history: makeHistoryDriver()});
 
-    sources.history.skip(1).subscribe({
+    sub = sources.history.skip(1).subscribe({
       next(location: Location) {
         assert.strictEqual(location.pathname, '/test');
         done();
@@ -65,7 +72,7 @@ describe.skip('historyDriver - RxJS', () => {
 
     const {sources, run} = setup(main, {history: makeHistoryDriver()});
 
-    sources.history.skip(1).subscribe({
+    sub = sources.history.skip(1).subscribe({
       next(location: Location) {
         assert.strictEqual(location.pathname, '/test');
         done();
@@ -87,7 +94,7 @@ describe.skip('historyDriver - RxJS', () => {
 
     const {sources, run} = setup(main, {history: makeHistoryDriver()});
 
-    sources.history.skip(1).subscribe({
+    sub = sources.history.skip(1).subscribe({
       next(location: Location) {
         assert.strictEqual(location.pathname, '/test');
         done();
@@ -125,7 +132,7 @@ describe.skip('historyDriver - RxJS', () => {
 
     const expected = ['/test', '/other', '/test', '/other', '/test', '/other'];
 
-    sources.history.skip(1).subscribe({
+    sub = sources.history.skip(1).subscribe({
       next(location: Location) {
         assert.strictEqual(location.pathname, expected.shift());
         if (expected.length === 0) {

--- a/history/test/browser/xstream.ts
+++ b/history/test/browser/xstream.ts
@@ -8,16 +8,23 @@ import {
   captureClicks,
   makeHistoryDriver,
 } from '../../src';
-import {run, setup} from '@cycle/run';
-import xs, {Stream} from 'xstream';
+import {setup} from '@cycle/run';
+import xs, {Stream, Subscription} from 'xstream';
 
 import {setAdapt} from '@cycle/run/lib/adapt';
 
 let dispose = () => {};
+let sub: Subscription | undefined;
 
 describe('historyDriver - xstream', () => {
   beforeEach(function() {
     setAdapt(x => x);
+  });
+
+  afterEach(function() {
+    if (sub) {
+      sub.unsubscribe();
+    }
     dispose();
   });
 
@@ -42,7 +49,7 @@ describe('historyDriver - xstream', () => {
 
     const {sources, run} = setup(main, {history: makeHistoryDriver()});
 
-    sources.history.drop(1).subscribe({
+    sub = sources.history.drop(1).subscribe({
       next(location: Location) {
         assert.strictEqual(location.pathname, '/test');
         done();
@@ -64,7 +71,7 @@ describe('historyDriver - xstream', () => {
 
     const {sources, run} = setup(main, {history: makeHistoryDriver()});
 
-    sources.history.drop(1).subscribe({
+    sub = sources.history.drop(1).subscribe({
       next(location: Location) {
         assert.strictEqual(location.pathname, '/test');
         done();
@@ -86,7 +93,7 @@ describe('historyDriver - xstream', () => {
 
     const {sources, run} = setup(main, {history: makeHistoryDriver()});
 
-    sources.history.drop(1).subscribe({
+    sub = sources.history.drop(1).subscribe({
       next(location: Location) {
         assert.strictEqual(location.pathname, '/test');
         done();
@@ -125,7 +132,7 @@ describe('historyDriver - xstream', () => {
 
     const expected = ['/test', '/other', '/test', '/other', '/test', '/other'];
 
-    sources.history.drop(1).subscribe({
+    sub = sources.history.drop(1).subscribe({
       next(location: Location) {
         assert.strictEqual(location.pathname, expected.shift());
         if (expected.length === 0) {

--- a/history/test/node/common.ts
+++ b/history/test/node/common.ts
@@ -3,7 +3,7 @@
 import * as assert from 'assert';
 import {Location, makeHistoryDriver, makeServerHistoryDriver} from '../../src';
 import {createMemoryHistory} from 'history';
-import xs from 'xstream';
+import xs, {Subscription} from 'xstream';
 
 describe('makeServerHistoryDriver', () => {
   it('should be a function', () => {
@@ -19,20 +19,22 @@ describe('makeServerHistoryDriver', () => {
     assert.strictEqual(typeof makeHistoryDriver(history), 'function');
   });
 
-  it('should start emitting the current location', function(done) {
-    const history$ = makeServerHistoryDriver()(xs.never());
+  it('should start emitting the current location synchronously', function(
+    done,
+  ) {
+    const sink = xs.never();
+    const history$ = makeServerHistoryDriver()(sink);
 
     const sub = history$.subscribe({
       next: (location: Location) => {
         assert(location.pathname);
         done();
       },
-      error: err => {},
+      error: done,
       complete: () => {},
     });
 
-    setTimeout(() => {
-      sub.unsubscribe();
-    });
+    sub.unsubscribe();
+    sink.shamefullySendComplete();
   });
 });

--- a/history/test/node/rxjs.ts
+++ b/history/test/node/rxjs.ts
@@ -1,11 +1,21 @@
 /// <reference path="../../node_modules/@types/mocha/index.d.ts" />
 /// <reference path="../../node_modules/@types/node/index.d.ts" />
 import * as assert from 'assert';
-import {Observable} from 'rxjs';
-import {setup, run} from '@cycle/rxjs-run';
+import {Observable, Subscription} from 'rxjs';
+import {setup} from '@cycle/rxjs-run';
 import {makeServerHistoryDriver, Location, HistoryInput} from '../../src';
 
+let dispose = () => {};
+let sub: Subscription | undefined;
+
 describe('serverHistoryDriver - RxJS', function() {
+  afterEach(function() {
+    dispose();
+    if (sub) {
+      sub.unsubscribe();
+    }
+  });
+
   it('should return an Rx Observable as source', function() {
     function main(sources: {history: Observable<Location>}) {
       assert.strictEqual(typeof sources.history.switchMap, 'function');
@@ -31,7 +41,7 @@ describe('serverHistoryDriver - RxJS', function() {
       history: makeServerHistoryDriver(),
     });
 
-    sources.history.skip(1).subscribe({
+    sub = sources.history.skip(1).subscribe({
       next(location: Location) {
         assert.strictEqual(location.pathname, '/test');
         done();
@@ -41,7 +51,7 @@ describe('serverHistoryDriver - RxJS', function() {
         done('complete should not be called');
       },
     });
-    run();
+    dispose = run();
   });
 
   it('should create a location from PushHistoryInput', done => {
@@ -55,7 +65,7 @@ describe('serverHistoryDriver - RxJS', function() {
       history: makeServerHistoryDriver(),
     });
 
-    sources.history.skip(1).subscribe({
+    sub = sources.history.skip(1).subscribe({
       next(location: Location) {
         assert.strictEqual(location.pathname, '/test');
         done();
@@ -65,7 +75,7 @@ describe('serverHistoryDriver - RxJS', function() {
         done('complete should not be called');
       },
     });
-    run();
+    dispose = run();
   });
 
   it('should create a location from ReplaceHistoryInput', done => {
@@ -79,7 +89,7 @@ describe('serverHistoryDriver - RxJS', function() {
       history: makeServerHistoryDriver(),
     });
 
-    sources.history.skip(1).subscribe({
+    sub = sources.history.skip(1).subscribe({
       next(location: Location) {
         assert.strictEqual(location.pathname, '/test');
         done();
@@ -89,7 +99,7 @@ describe('serverHistoryDriver - RxJS', function() {
         done('complete should not be called');
       },
     });
-    run();
+    dispose = run();
   });
 
   it('should allow going back a route with type `go`', done => {
@@ -108,7 +118,7 @@ describe('serverHistoryDriver - RxJS', function() {
 
     const expected = ['/test', '/other', '/test'];
 
-    sources.history.skip(1).subscribe({
+    sub = sources.history.skip(1).subscribe({
       next(location: Location) {
         assert.strictEqual(location.pathname, expected.shift());
         if (expected.length === 0) {
@@ -120,7 +130,7 @@ describe('serverHistoryDriver - RxJS', function() {
         done('complete should not be called');
       },
     });
-    run();
+    dispose = run();
   });
 
   it('should allow going back a route with type `goBack`', done => {
@@ -138,7 +148,7 @@ describe('serverHistoryDriver - RxJS', function() {
 
     const expected = ['/test', '/other', '/test'];
 
-    sources.history.skip(1).subscribe({
+    sub = sources.history.skip(1).subscribe({
       next(location: Location) {
         assert.strictEqual(location.pathname, expected.shift());
         if (expected.length === 0) {
@@ -150,7 +160,7 @@ describe('serverHistoryDriver - RxJS', function() {
         done('complete should not be called');
       },
     });
-    run();
+    dispose = run();
   });
 
   it('should allow going forward a route with type `go`', done => {
@@ -171,7 +181,7 @@ describe('serverHistoryDriver - RxJS', function() {
 
     const expected = ['/test', '/other', '/test', '/other'];
 
-    sources.history.skip(1).subscribe({
+    sub = sources.history.skip(1).subscribe({
       next(location: Location) {
         assert.strictEqual(location.pathname, expected.shift());
         if (expected.length === 0) {
@@ -183,7 +193,7 @@ describe('serverHistoryDriver - RxJS', function() {
         done('complete should not be called');
       },
     });
-    run();
+    dispose = run();
   });
 
   it('should allow going forward a route with type `goForward`', done => {
@@ -204,7 +214,7 @@ describe('serverHistoryDriver - RxJS', function() {
 
     const expected = ['/test', '/other', '/test', '/other'];
 
-    sources.history.skip(1).subscribe({
+    sub = sources.history.skip(1).subscribe({
       next(location: Location) {
         assert.strictEqual(location.pathname, expected.shift());
         if (expected.length === 0) {
@@ -216,6 +226,6 @@ describe('serverHistoryDriver - RxJS', function() {
         done('complete should not be called');
       },
     });
-    run();
+    dispose = run();
   });
 });

--- a/history/test/node/xstream.ts
+++ b/history/test/node/xstream.ts
@@ -1,14 +1,24 @@
 /// <reference path="../../node_modules/@types/mocha/index.d.ts" />
 /// <reference path="../../node_modules/@types/node/index.d.ts" />
 import * as assert from 'assert';
-import xs, {Stream} from 'xstream';
-import {setup, run} from '@cycle/run';
+import xs, {Stream, Subscription} from 'xstream';
+import {setup} from '@cycle/run';
 import {setAdapt} from '@cycle/run/lib/adapt';
 import {makeServerHistoryDriver, Location, HistoryInput} from '../../src';
+
+let dispose = () => {};
+let sub: Subscription | undefined;
 
 describe('serverHistoryDriver - xstream', function() {
   beforeEach(function() {
     setAdapt(x => x);
+  });
+
+  afterEach(function() {
+    if (sub) {
+      sub.unsubscribe();
+    }
+    dispose();
   });
 
   it('should return a stream', function() {
@@ -36,7 +46,7 @@ describe('serverHistoryDriver - xstream', function() {
       history: makeServerHistoryDriver(),
     });
 
-    sources.history.drop(1).subscribe({
+    sub = sources.history.drop(1).subscribe({
       next(location: Location) {
         assert.strictEqual(location.pathname, '/test');
         done();
@@ -46,7 +56,7 @@ describe('serverHistoryDriver - xstream', function() {
         done('complete should not be called');
       },
     });
-    run();
+    dispose = run();
   });
 
   it('should create a location from PushHistoryInput', done => {
@@ -60,7 +70,7 @@ describe('serverHistoryDriver - xstream', function() {
       history: makeServerHistoryDriver(),
     });
 
-    sources.history.drop(1).subscribe({
+    sub = sources.history.drop(1).subscribe({
       next(location: Location) {
         assert.strictEqual(location.pathname, '/test');
         done();
@@ -70,7 +80,7 @@ describe('serverHistoryDriver - xstream', function() {
         done('complete should not be called');
       },
     });
-    run();
+    dispose = run();
   });
 
   it('should create a location from ReplaceHistoryInput', done => {
@@ -84,7 +94,7 @@ describe('serverHistoryDriver - xstream', function() {
       history: makeServerHistoryDriver(),
     });
 
-    sources.history.drop(1).subscribe({
+    sub = sources.history.drop(1).subscribe({
       next(location: Location) {
         assert.strictEqual(location.pathname, '/test');
         done();
@@ -94,7 +104,7 @@ describe('serverHistoryDriver - xstream', function() {
         done('complete should not be called');
       },
     });
-    run();
+    dispose = run();
   });
 
   it('should allow going back a route with type `go`', done => {
@@ -113,7 +123,7 @@ describe('serverHistoryDriver - xstream', function() {
 
     const expected = ['/test', '/other', '/test'];
 
-    sources.history.drop(1).subscribe({
+    sub = sources.history.drop(1).subscribe({
       next(location: Location) {
         assert.strictEqual(location.pathname, expected.shift());
         if (expected.length === 0) {
@@ -125,7 +135,7 @@ describe('serverHistoryDriver - xstream', function() {
         done('complete should not be called');
       },
     });
-    run();
+    dispose = run();
   });
 
   it('should allow going back a route with type `goBack`', done => {
@@ -143,7 +153,7 @@ describe('serverHistoryDriver - xstream', function() {
 
     const expected = ['/test', '/other', '/test'];
 
-    sources.history.drop(1).subscribe({
+    sub = sources.history.drop(1).subscribe({
       next(location: Location) {
         assert.strictEqual(location.pathname, expected.shift());
         if (expected.length === 0) {
@@ -155,7 +165,7 @@ describe('serverHistoryDriver - xstream', function() {
         done('complete should not be called');
       },
     });
-    run();
+    dispose = run();
   });
 
   it('should allow going forward a route with type `go`', done => {
@@ -176,7 +186,7 @@ describe('serverHistoryDriver - xstream', function() {
 
     const expected = ['/test', '/other', '/test', '/other'];
 
-    sources.history.drop(1).subscribe({
+    sub = sources.history.drop(1).subscribe({
       next(location: Location) {
         assert.strictEqual(location.pathname, expected.shift());
         if (expected.length === 0) {
@@ -188,7 +198,7 @@ describe('serverHistoryDriver - xstream', function() {
         done('complete should not be called');
       },
     });
-    run();
+    dispose = run();
   });
 
   it('should allow going forward a route with type `goForward`', done => {
@@ -209,7 +219,7 @@ describe('serverHistoryDriver - xstream', function() {
 
     const expected = ['/test', '/other', '/test', '/other'];
 
-    sources.history.drop(1).subscribe({
+    sub = sources.history.drop(1).subscribe({
       next(location: Location) {
         assert.strictEqual(location.pathname, expected.shift());
         if (expected.length === 0) {
@@ -221,6 +231,6 @@ describe('serverHistoryDriver - xstream', function() {
         done('complete should not be called');
       },
     });
-    run();
+    dispose = run();
   });
 });


### PR DESCRIPTION
Tests were skipped because of global state, with this cleanup
we should be able to not skip any tests ... just always cleanup everything

<!--
Thank you for your contribution! You're awesome.
To help speed up the process of merging your code, check the following:
-->

- [ ] There exists an issue discussing the need for this PR
- [x] I added new tests for the issue I fixed or built
- [x] I ran `make test FOO` for the package FOO I'm modifying
- [x] I used `make commit` instead of `git commit`
