### PR TITLE
gitignore lib/cjs and lib/es6 instead of lib

### DIFF
--- a/dom/.gitignore
+++ b/dom/.gitignore
@@ -9,7 +9,8 @@ node_modules/
 
 # Generated
 test/browser/page/tests-bundle.js
-lib/
+lib/cjs/
+lib/es6/
 dist/
 
 # Misc

--- a/dom/.gitignore
+++ b/dom/.gitignore
@@ -9,8 +9,9 @@ node_modules/
 
 # Generated
 test/browser/page/tests-bundle.js
-lib/cjs/
-lib/es6/
+/lib/cjs/
+/lib/es6/
+/test/browser/lib
 dist/
 
 # Misc

--- a/history/.gitignore
+++ b/history/.gitignore
@@ -1,4 +1,5 @@
-lib/
+lib/cjs/
+lib/es6/
 dist/
 node_modules
 npm-debug.log

--- a/html/.gitignore
+++ b/html/.gitignore
@@ -9,7 +9,8 @@ node_modules/
 
 # Generated
 test/browser/page/tests-bundle.js
-lib/
+lib/cjs/
+lib/es6/
 dist/
 
 # Misc

--- a/http/.gitignore
+++ b/http/.gitignore
@@ -9,7 +9,8 @@ node_modules
 
 # Generated
 test/browser/page/tests-bundle.js
-lib/
+lib/cjs/
+lib/es6/
 dist/
 test-support-server.pid
 

--- a/http/.gitignore
+++ b/http/.gitignore
@@ -9,8 +9,9 @@ node_modules
 
 # Generated
 test/browser/page/tests-bundle.js
-lib/cjs/
-lib/es6/
+/lib/cjs/
+/lib/es6/
+/test/browser/lib/
 dist/
 test-support-server.pid
 

--- a/isolate/.gitignore
+++ b/isolate/.gitignore
@@ -8,7 +8,8 @@
 node_modules
 
 # Generated
-lib/
+lib/cjs/
+lib/es6/
 dist/
 
 # Misc

--- a/most-run/.gitignore
+++ b/most-run/.gitignore
@@ -4,6 +4,7 @@
 node_modules
 npm-debug.log
 
-lib/
+lib/cjs/
+lib/es6/
 coverage/
 dist/

--- a/run/.gitignore
+++ b/run/.gitignore
@@ -8,7 +8,8 @@
 node_modules
 
 # Generated
-lib/
+lib/cjs/
+lib/es6/
 dist/
 
 # Misc

--- a/run/.gitignore
+++ b/run/.gitignore
@@ -8,8 +8,9 @@
 node_modules
 
 # Generated
-lib/cjs/
-lib/es6/
+lib/cjs
+lib/es6
+lib/
 dist/
 
 # Misc

--- a/rxjs-run/.gitignore
+++ b/rxjs-run/.gitignore
@@ -8,7 +8,8 @@
 node_modules
 
 # Generated
-lib/
+lib/cjs/
+lib/es6/
 dist/
 
 # Misc

--- a/time/.gitignore
+++ b/time/.gitignore
@@ -43,7 +43,8 @@ jspm_packages
 .settings
 
 # Generated
-/lib/
+/lib/cjs/
+/lib/es6/
 /dist/
 /most.js
 /rxjs.js


### PR DESCRIPTION
This should help prevent accidental inclusion of old build artifacts in packages.