### PR TITLE
Fix error propagation in @cycle/time

### DIFF
--- a/time/most.ts
+++ b/time/most.ts
@@ -18,6 +18,7 @@ interface TimeSource {
   throttle(period: number): Operator;
   periodic(period: number): Stream<number>;
   throttleAnimation: Operator;
+  dispose(): void;
 }
 
 interface MockTimeSource extends TimeSource {

--- a/time/rxjs.ts
+++ b/time/rxjs.ts
@@ -20,6 +20,7 @@ interface TimeSource {
   throttle(period: number): Operator;
   periodic(period: number): Observable<number>;
   throttleAnimation: Operator;
+  dispose(): void;
 }
 
 interface MockTimeSource extends TimeSource {

--- a/time/src/debounce.ts
+++ b/time/src/debounce.ts
@@ -26,11 +26,11 @@ function makeDebounceListener<T>(
     },
 
     error(e: any) {
-      schedule.error(listener, currentTime(), e);
+      listener.error(e);
     },
 
     complete() {
-      schedule.complete(listener, currentTime());
+      listener.complete();
     },
   };
 }

--- a/time/src/periodic.ts
+++ b/time/src/periodic.ts
@@ -46,7 +46,7 @@ function makePeriodic(createOperator: () => OperatorArgs<any>) {
 
       stop() {
         stopped = true;
-        schedule.complete(producer.listener as Listener<any>, currentTime());
+        (producer.listener as Listener<any>).complete();
       },
     };
 

--- a/time/src/throttle-animation.ts
+++ b/time/src/throttle-animation.ts
@@ -19,7 +19,7 @@ function makeThrottleAnimation(
         const animationListener = {
           next(event: any) {
             if (!emittedLastValue) {
-              schedule.next(listener, currentTime(), lastValue);
+              listener.next(lastValue);
               emittedLastValue = true;
             }
           },
@@ -32,12 +32,12 @@ function makeThrottleAnimation(
           },
 
           error(err: Error) {
-            schedule.error(listener, currentTime(), err);
+            listener.error(err);
           },
 
           complete() {
             frame$.removeListener(animationListener);
-            schedule.complete(listener, currentTime());
+            listener.complete();
           },
         });
 

--- a/time/src/throttle.ts
+++ b/time/src/throttle.ts
@@ -27,11 +27,11 @@ function makeThrottleListener<T>(
     },
 
     error(error: any) {
-      schedule.error(listener, currentTime(), error);
+      listener.error(error);
     },
 
     complete() {
-      schedule.complete(listener, currentTime());
+      listener.complete();
     },
   };
 }

--- a/time/src/time-driver.ts
+++ b/time/src/time-driver.ts
@@ -8,7 +8,7 @@ import {makeAnimationFrames} from './animation-frames';
 import {makeThrottleAnimation} from './throttle-animation';
 import {runVirtually} from './run-virtually';
 import {TimeSource} from './time-source';
-import {requestAnimationFrame} from 'raf';
+import * as requestAnimationFrame from 'raf';
 import * as now from 'performance-now';
 
 function popAll(array: Array<any>): Array<any> {

--- a/time/src/time-driver.ts
+++ b/time/src/time-driver.ts
@@ -139,6 +139,7 @@ function timeDriver(sink: any): any {
       // TODO - frameCallbacks?
       runVirtually(scheduler, done, currentTime, setTime, timeToRunTo);
     },
+    dispose: pause,
 
     createOperator,
   };

--- a/time/src/time-driver.ts
+++ b/time/src/time-driver.ts
@@ -80,6 +80,12 @@ function runRealtime(
         if (eventToProcess.type === 'complete') {
           eventToProcess.stream.shamefullySendComplete();
         }
+
+        if (eventToProcess.type === 'error') {
+          eventToProcess.stream.shamefullySendError(eventToProcess.error);
+        }
+
+        throw new Error('Unhandled event type: ' + eventToProcess.type);
       }
 
       nextEventTime = (scheduler.peek() && scheduler.peek().time) || Infinity;

--- a/time/src/time-source.ts
+++ b/time/src/time-source.ts
@@ -12,6 +12,7 @@ export interface TimeSource {
   throttle(period: number): Operator;
   periodic(period: number): Stream<number>;
   throttleAnimation: Operator;
+  dispose(): void;
 }
 
 export interface MockTimeSource extends TimeSource {

--- a/time/test/time-driver.ts
+++ b/time/test/time-driver.ts
@@ -1,0 +1,20 @@
+
+import * as assert from 'assert';
+import {timeDriver, TimeSource, Operator} from '../';
+import xs, {Stream} from 'xstream';
+import {setAdapt} from '@cycle/run/lib/adapt';
+
+describe('time driver', () => {
+  before(() => setAdapt(s => s));
+
+  it('propagates errors', (done) => {
+    const Time = timeDriver(xs.empty());
+
+    xs.throw(new Error()).compose(Time.debounce(1)).addListener({
+      error (err: Error) {
+        done();
+        Time.dispose();
+      }
+    })
+  });
+});


### PR DESCRIPTION
Fixes #754.

This is a very bad bug, that I really should have caught. I never handled error events in the production scheduler, so any scheduled error was swallowed.

To address this, I have added a unit test, handled the error case, added a safeguard runtime error to ease regression detection, and then short-circuited the scheduler for the majority of the cases where this would occur.

I also added a simple dispose function for the unit test, that will still need to be elaborated in future.