### PR TITLE
fix(time): fix throttle immediately completing with sync producer

### DIFF
--- a/time/src/assert-equal.ts
+++ b/time/src/assert-equal.ts
@@ -30,7 +30,9 @@ function checkEqual(
 
     if (actual.type !== expected.type) {
       failReasons.push(
-        `Expected type ${expected.type} at time ${actual.time} but got ${actual.type}`,
+        `Expected type ${expected.type} at time ${actual.time} but got ${
+          actual.type
+        }`,
       );
     }
 
@@ -41,7 +43,9 @@ function checkEqual(
 
       if (!rightTime) {
         failReasons.push(
-          `Expected stream to complete at ${expected.time} but completed at ${actual.time}`,
+          `Expected stream to complete at ${expected.time} but completed at ${
+            actual.time
+          }`,
         );
       }
     }
@@ -71,7 +75,9 @@ function checkEqual(
 
       if (!rightTime || !rightValue) {
         const errorMessage = [
-          `Expected value at time ${expected.time} but got different value at ${actual.time}\n`,
+          `Expected value at time ${expected.time} but got different value at ${
+            actual.time
+          }\n`,
         ];
 
         if (usingCustomComparator) {

--- a/time/src/throttle.ts
+++ b/time/src/throttle.ts
@@ -31,7 +31,7 @@ function makeThrottleListener<T>(
     },
 
     complete() {
-      listener.complete();
+      schedule.complete(listener, currentTime());
     },
   };
 }

--- a/time/test/time-driver.ts
+++ b/time/test/time-driver.ts
@@ -1,4 +1,3 @@
-
 import * as assert from 'assert';
 import {timeDriver, TimeSource, Operator} from '../';
 import xs, {Stream} from 'xstream';
@@ -7,14 +6,42 @@ import {setAdapt} from '@cycle/run/lib/adapt';
 describe('time driver', () => {
   before(() => setAdapt(s => s));
 
-  it('propagates errors', (done) => {
+  it('propagates events passed through operators', done => {
     const Time = timeDriver(xs.empty());
 
-    xs.throw(new Error()).compose(Time.debounce(1)).addListener({
-      error (err: Error) {
-        done();
-        Time.dispose();
-      }
-    })
+    const expected = [1, 2, 3];
+
+    xs
+      .of(1, 2, 3)
+      .compose(Time.delay(1))
+      .addListener({
+        next(n: number) {
+          assert.equal(n, expected.shift());
+        },
+
+        complete() {
+          assert.equal(expected.length, 0);
+
+          done();
+
+          Time.dispose();
+        },
+
+        error: done,
+      });
+  });
+
+  it('propagates errors', done => {
+    const Time = timeDriver(xs.empty());
+
+    xs
+      .throw(new Error())
+      .compose(Time.debounce(1))
+      .addListener({
+        error(err: Error) {
+          done();
+          Time.dispose();
+        },
+      });
   });
 });

--- a/time/test/time.ts
+++ b/time/test/time.ts
@@ -616,6 +616,19 @@ describe('@cycle/time', () => {
 
             Time.run(done);
           });
+
+          context('with a synchronous stream', () => {
+            it('fires an event before completing', done => {
+              const Time = mockTimeSource();
+
+              const stream = library.adapt(xs.from([1, 2, 3]));
+              const expected = Time.diagram('(1|)');
+
+              Time.assertEqual(compose(stream, Time.throttle(60)), expected);
+
+              Time.run(done);
+            });
+          });
         });
 
         describe('.animationFrames', () => {


### PR DESCRIPTION
v0.12.0 introduced a regression where applying throttle to synchronous
source (like xs.of or xs.from) would cause the resulting stream to
immediately complete, before firing an event.

This was not a documented behaviour, but @cycle/time consistently
processes next events prior to completion events if they occur in the
same frame.

I have added a unit test to prevent any regressions to this behaviour in
the future.

Thanks to @willheslam for reporting this issue.

This fixes #770.