### PR TITLE
Add required modules for babel/jsx to npm install.

### DIFF
--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -183,7 +183,7 @@ We used the `div()`, `input()`, `p()` helper functions to create virtual DOM ele
 (1) Install the npm packages [babel-plugin-transform-react-jsx](http://babeljs.io/docs/plugins/transform-react-jsx/) and [snabbdom-jsx](https://www.npmjs.com/package/snabbdom-jsx).
 
 ```
-npm install --save babel-plugin-transform-react-jsx snabbdom-jsx
+npm install --save babel-cli babel-preset-es2015 babel-plugin-transform-react-jsx snabbdom-jsx
 ```
 
 (2) Specify a pragma for JSX in the `.babelrc` file.


### PR DESCRIPTION
I needed to also install babel-cli and babel-preset-es2015 to run a basic jsx example. In fact I also need babelify since I was using browserify, but didn't add that to the example since the bundler is not specified.