### PR TITLE
 docs(suggestion): use template string for "Send Messages from main" section

### DIFF
--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -132,7 +132,7 @@ We have filled the `main()` function with some code: returns an object `sinks` w
 function main() {
   const sinks = {
     DOM: xs.periodic(1000).map(i =>
-      h1('' + i + ' seconds elapsed')
+      h1(`${i} seconds elapsed`)
     )
   };
   return sinks;
@@ -288,19 +288,19 @@ In the rare occasion you need Cycle.js scripts as standalone JavaScript files, y
         <div role='flatdoc-menu'></div>
 
         <ul>
-  
+
             <li><a href="dialogue.html" class="level-1 out-link">Dialogue abstraction</a></li>
-  
+
             <li><a href="streams.html" class="level-1 out-link">Streams</a></li>
-  
+
             <li><a href="basic-examples.html" class="level-1 out-link">Basic examples</a></li>
-  
+
             <li><a href="model-view-intent.html" class="level-1 out-link">Model-View-Intent</a></li>
-  
+
             <li><a href="components.html" class="level-1 out-link">Components</a></li>
-  
+
             <li><a href="drivers.html" class="level-1 out-link">Drivers</a></li>
-  
+
         </ul>
 
       </div>

--- a/time/src/time-driver.ts
+++ b/time/src/time-driver.ts
@@ -75,17 +75,13 @@ function runRealtime(
 
         if (eventToProcess.type === 'next') {
           eventToProcess.stream.shamefullySendNext(eventToProcess.value);
-        }
-
-        if (eventToProcess.type === 'complete') {
+        } else if (eventToProcess.type === 'complete') {
           eventToProcess.stream.shamefullySendComplete();
-        }
-
-        if (eventToProcess.type === 'error') {
+        } else if (eventToProcess.type === 'error') {
           eventToProcess.stream.shamefullySendError(eventToProcess.error);
+        } else {
+          throw new Error('Unhandled event type: ' + eventToProcess.type);
         }
-
-        throw new Error('Unhandled event type: ' + eventToProcess.type);
       }
 
       nextEventTime = (scheduler.peek() && scheduler.peek().time) || Infinity;


### PR DESCRIPTION
- [ ] There exists an issue discussing the need for this PR
- [ ] I added new tests for the issue I fixed or built
- [ ] I ran `make test FOO` for the package FOO I'm modifying
- [x] I used `make commit` instead of `git commit`

**This is just a suggestion.**

In the section ["Send messages from main"](https://cycle.js.org/getting-started.html#getting-started-coding-send-messages-from-main), instead of:

```javascript
'' + i + ' seconds elapsed'
```

I think is better to use template string, so we can actually match the documentation that says: `The stream emits Virtual DOM <h1> elements displaying ${i} seconds elapsed changing over time every second, where ${i} is replaced by 0, 1, 2, etc.`

What do you think?