### PR TITLE
fix(time): fix rxjs and most entrypoints

### DIFF
--- a/time/most.ts
+++ b/time/most.ts
@@ -2,10 +2,10 @@ import * as most from 'most';
 import {Stream} from 'most';
 import {setAdapt} from '@cycle/run/lib/adapt';
 
-import {mockTimeSource as mockTimeSourceUntyped} from './src/mock-time-source';
-import {timeDriver as timeDriverUntyped} from './src/time-driver';
-import {Frame} from './src/animation-frames';
-import {Comparator, OperatorArgs} from './src/types';
+import {mockTimeSource as mockTimeSourceUntyped} from './lib/cjs/src/mock-time-source';
+import {timeDriver as timeDriverUntyped} from './lib/cjs/src/time-driver';
+import {Frame} from './lib/cjs/src/animation-frames';
+import {Comparator, OperatorArgs} from './lib/cjs/src/types';
 
 setAdapt(stream => most.from(stream as any));
 

--- a/time/package.json
+++ b/time/package.json
@@ -59,6 +59,7 @@
     "test-ci": "npm run test",
     "test-docs": "markdown-doctest",
     "browserify": "../node_modules/.bin/browserify lib/cjs/index.js --global-transform=browserify-shim --standalone CycleTime --exclude xstream --outfile dist/cycle-time.js",
-    "minify": "node ../.scripts/minify.js dist/cycle-time.js dist/cycle-time.min.js"
+    "minify": "node ../.scripts/minify.js dist/cycle-time.js dist/cycle-time.min.js",
+    "postlib": "tsc rxjs.ts most.ts --declaration --lib DOM,ES5,ES6"
   }
 }

--- a/time/rxjs.ts
+++ b/time/rxjs.ts
@@ -3,10 +3,10 @@ import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/observable/from';
 import {setAdapt} from '@cycle/run/lib/adapt';
 
-import {mockTimeSource as mockTimeSourceUntyped} from './src/mock-time-source';
-import {timeDriver as timeDriverUntyped} from './src/time-driver';
-import {Frame} from './src/animation-frames';
-import {Comparator, OperatorArgs} from './src/types';
+import {mockTimeSource as mockTimeSourceUntyped} from './lib/cjs/src/mock-time-source';
+import {timeDriver as timeDriverUntyped} from './lib/cjs/src/time-driver';
+import {Frame} from './lib/cjs/src/animation-frames';
+import {Comparator, OperatorArgs} from './lib/cjs/src/types';
 
 setAdapt(stream => Observable.from(stream));
 

--- a/time/tsconfig.json
+++ b/time/tsconfig.json
@@ -12,8 +12,6 @@
   },
   "files": [
     "index.ts",
-    "most.ts",
-    "rxjs.ts",
     "custom-typings.d.ts"
   ]
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! You're awesome.
To help speed up the process of merging your code, check the following:
-->

Fixes #779.

I recognise that this doesn't allow most/rxjs users to use ES6 sources, I but I think that having it work at all would be an improvement over the current situation. We should tackle ES6 sources in a separate PR.

- [x] There exists an issue discussing the need for this PR
- [ ] I added new tests for the issue I fixed or built
- [x] I ran `make test FOO` for the package FOO I'm modifying
- [x] I used `make commit` instead of `git commit`
