### PR TITLE
chore(META): replace bump-cli with simple bump script

### DIFF
--- a/.scripts/bump.js
+++ b/.scripts/bump.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+const path = require('path');
+const fs = require('fs');
+
+const packagePath = process.argv[2];
+const bumpType = process.argv[3];
+
+if (!packagePath || packagePath === '') {
+  console.log("Please provide a relative package.json path as the first argument");
+  process.exit(1);
+}
+
+const packageJSON = require(path.join(process.cwd(), packagePath));
+
+const version = packageJSON.version;
+
+let [major, minor, patch, ...others] = version.split('.').map(s => parseInt(s, 10));
+
+if (bumpType == '--major') {
+  major += 1;
+} else if (bumpType == '--minor') {
+  minor += 1;
+} else if (bumpType == '--patch') {
+  patch += 1;
+} else {
+  console.log("Please specify --major, --minor or --patch as the second argument");
+  process.exit(1);
+}
+
+packageJSON.version = [major, minor, patch, ...others].join('.');
+
+fs.writeFileSync(packagePath, JSON.stringify(packageJSON, null, 2) + "\n");

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TSLINT=$(BINDIR)/tslint
 TSC=$(BINDIR)/tsc
 MOCHA=$(BINDIR)/mocha
 BROWSERIFY=$(BINDIR)/browserify
-BUMP=$(BINDIR)/bump
+BUMP=.scripts/bump.js
 JASE=$(BINDIR)/jase
 TESTEM=$(BINDIR)/testem
 
@@ -175,7 +175,7 @@ release-minor :
 		echo "Error: please call 'make release-minor' with an argument, like 'make release-minor dom'" ;\
 	else \
 		make prebump $(ARG) ;\
-		$(BUMP) $(ARG)/package.json --quiet --minor ;\
+		$(BUMP) $(ARG)/package.json --minor ;\
 		make postbump $(ARG) ;\
 		echo "✓ Released new minor for $(ARG)" ;\
 	fi
@@ -185,7 +185,7 @@ release-major :
 		echo "Error: please call 'make release-major' with an argument, like 'make release-major dom'" ;\
 	else \
 		make prebump $(ARG) ;\
-		$(BUMP) $(ARG)/package.json --quiet --major ;\
+		$(BUMP) $(ARG)/package.json --major ;\
 		make postbump $(ARG) ;\
 		echo "✓ Released new major for $(ARG)" ;\
 	fi

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "browserify": "13.3.0",
     "browserify-shim": "3.8.13",
     "budo": "10.0.x",
-    "bump-cli": "^1.1.3",
     "commitizen": "2.9.6",
     "conventional-changelog": "1.1.6",
     "conventional-changelog-cli": "1.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -720,13 +720,6 @@ builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
 
-bump-cli@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/bump-cli/-/bump-cli-1.1.3.tgz#f9554dd5a38dca5d652afde372c59368bb8c6c65"
-  dependencies:
-    minimist "^1.1.0"
-    semver "^3.0.1"
-
 bytes@2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.4.0.tgz#7d97196f9d5baf7f6935e25985549edd2a6c2339"


### PR DESCRIPTION
Closes #737.

Unlike bump-cli, bump.js can bump from 19.0.0 to 20.0.0, rather than to
110.0.0.

<!--
Thank you for your contribution!
To help speed up the process of merging your code, check the following:
-->

- [x] There exists an issue discussing the need for this PR
- [ ] I added new tests for the issue I fixed or built
- [x] I used `make commit` instead of `git commit`
