### PR TITLE
docs(META): use ES6 syntax in getting-started

### DIFF
--- a/docs/content/documentation/getting-started.md
+++ b/docs/content/documentation/getting-started.md
@@ -101,7 +101,7 @@ We have filled the `main()` function with some code: returns an object `sinks` w
 function main() {
   const sinks = {
     DOM: xs.periodic(1000).map(i =>
-      h1('' + i + ' seconds elapsed')
+      h1(`${i} seconds elapsed`)
     )
   };
   return sinks;

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -132,7 +132,7 @@ We have filled the `main()` function with some code: returns an object `sinks` w
 function main() {
   const sinks = {
     DOM: xs.periodic(1000).map(i =>
-      h1('' + i + ' seconds elapsed')
+      h1(`${i} seconds elapsed`)
     )
   };
   return sinks;


### PR DESCRIPTION
The text above that piece of code is using ES6 syntax to reference `i`

<!--
Thank you for your contribution!
To help speed up the process of merging your code, check the following:
-->

- [ ] There exists an issue discussing the need for this PR
- [ ] I added new tests for the issue I fixed or built
- [x] I used `make commit` instead of `git commit`

I didn't mind making an issue for this small change. Apologies if I should have done it.
