### PR TITLE
Allow array of VDOM

### DIFF
--- a/dom/src/VNodeWrapper.ts
+++ b/dom/src/VNodeWrapper.ts
@@ -29,7 +29,7 @@ export class VNodeWrapper {
       return vnode;
     }
 
-    return this.wrap([vnode]);
+    return this.wrap(Array.isArray(vnode) ? vnode : [vnode]);
   }
 
   private wrapDocFrag(children: Array<VNode>) {


### PR DESCRIPTION
Allow array of VDOM objects to be passed to the DOMDriver sink. No need to wrap sibling elements in parent element. This is particularly useful when patching the HTML document HEAD.

I attempted to run tests but get this error: 
`test/node/mock-dom-source.ts (14,8): Cannot find module '../../lib/cjs/index'. (2307)`

https://github.com/cyclejs/cyclejs/blob/master/dom/test/node/mock-dom-source.ts#L14

I don't see that directory in the git repository.