### PR TITLE
fix(dom): postpone sampling of root element until DOM is ready.

### DIFF
--- a/dom/src/makeDOMDriver.ts
+++ b/dom/src/makeDOMDriver.ts
@@ -143,8 +143,8 @@ function makeDOMDriver(
       )
       .flatten();
 
-    const rootElement$ = mutationConfirmed$
-      .startWith(null)
+    const rootElement$ = xs
+      .merge(domReady$, mutationConfirmed$)
       .endWhen(sanitation$)
       .compose(sampleCombine(elementAfterPatch$))
       .map(arr => arr[1])

--- a/dom/src/makeDOMDriver.ts
+++ b/dom/src/makeDOMDriver.ts
@@ -2,6 +2,7 @@ import {Driver, FantasyObservable} from '@cycle/run';
 import {init} from 'snabbdom';
 import {Module} from 'snabbdom/modules/module';
 import xs, {Stream, Listener} from 'xstream';
+import concat from 'xstream/extra/concat';
 import sampleCombine from 'xstream/extra/sampleCombine';
 import {DOMSource} from './DOMSource';
 import {MainDOMSource} from './MainDOMSource';
@@ -143,8 +144,7 @@ function makeDOMDriver(
       )
       .flatten();
 
-    const rootElement$ = xs
-      .merge(domReady$, mutationConfirmed$)
+    const rootElement$ = concat(domReady$, mutationConfirmed$)
       .endWhen(sanitation$)
       .compose(sampleCombine(elementAfterPatch$))
       .map(arr => arr[1])


### PR DESCRIPTION
The elementAfterPath$ stream was immediately sampled, while elementAfterPath$ only starts emitting
once the DOM is ready, causing the first emission of elementAfterPath$ to be missed. By postponing
the first sample of elementAfterPath$ until the DOM is ready, we make sure that we don't miss this
first emission.

ISSUES CLOSED: #791

<!--
Thank you for your contribution!
To help speed up the process of merging your code, check the following:
-->

- [x] There exists an issue discussing the need for this PR
- [ ] I added new tests for the issue I fixed or built
- [x] I used `make commit` instead of `git commit`
