### PR TITLE
Do Not Duplicate Root Elements w/o ID

### DIFF
--- a/dom/src/VNodeWrapper.ts
+++ b/dom/src/VNodeWrapper.ts
@@ -13,7 +13,7 @@ export class VNodeWrapper {
     if (vnode === null) {
       return this.wrap([]);
     }
-    const {tagName: selTagName, id: selId} = selectorParser(vnode);
+    const {tagName: selTagName, id: selId = ''} = selectorParser(vnode);
     const vNodeClassName = classNameFromVNode(vnode);
     const vNodeData = vnode.data || {};
     const vNodeDataProps = vNodeData.props || {};


### PR DESCRIPTION
Do not duplicate the root element when not using ID property. For example, without this PR, when simply targeting the HEAD tag it gets duplicated because there is no associated ID. This PR simply gives the `selId` variable a default value of empty string, which correlate it with the default value of empty string given to the ID property of the `rootElement` object by `document.querySelector`.

Discussions here:
https://github.com/cyclejs/cyclejs/pull/792
https://github.com/cyclejs/cyclejs/issues/540

---------

- [ ] Has valid commit message
- [ ] Has tests