### PR TITLE
Add duplicate root element fix test

### DIFF
--- a/dom/test/browser/src/dom-driver.ts
+++ b/dom/test/browser/src/dom-driver.ts
@@ -231,4 +231,26 @@ describe('DOM Driver', function() {
       }, 50);
     }, 100);
   });
+
+  it('should not duplicate root element when not having ID property set', function(done) {
+    function app() {
+      return {
+        DOM: xs.of(div('dummy text')),
+      };
+    }
+
+    const {sinks, sources, run} = setup(app, {
+      DOM: makeDOMDriver(createRenderTarget()),
+    });
+
+    const dispose = run();
+    setTimeout(() => {
+      dispose();
+      setTimeout(() => {
+        const renderTarget = document.querySelector('div') as Element;
+        assert.equal(renderTarget.children.length, 0);
+        done();
+      }, 50);
+    }, 100);
+  });
 });


### PR DESCRIPTION
Adding a test to verify that root element is not duplicated when it's ID property is not set.

Test for PR https://github.com/cyclejs/cyclejs/pull/794

I'm not able to run tests in my CycleJS download. I get this error:
```
TSError: ⨯ Unable to compile TypeScript
test/node/mock-dom-source.ts (14,8): Cannot find module '../../lib/cjs/index'.
```