### PR TITLE
Fix duplicate root element not having ID bug.

### DIFF
--- a/dom/src/VNodeWrapper.ts
+++ b/dom/src/VNodeWrapper.ts
@@ -13,7 +13,7 @@ export class VNodeWrapper {
     if (vnode === null) {
       return this.wrap([]);
     }
-    const {tagName: selTagName, id: selId} = selectorParser(vnode);
+    const {tagName: selTagName, id: selId = ''} = selectorParser(vnode);
     const vNodeClassName = classNameFromVNode(vnode);
     const vNodeData = vnode.data || {};
     const vNodeDataProps = vNodeData.props || {};

--- a/dom/test/browser/page/index.html
+++ b/dom/test/browser/page/index.html
@@ -7,6 +7,7 @@
   </head>
   <body>
     <div id="mocha"></div>
+    <footer></footer>
     <script type="text/javascript">
       var isIE10 = false;
       /*@cc_on

--- a/dom/test/browser/src/events.ts
+++ b/dom/test/browser/src/events.ts
@@ -513,7 +513,7 @@ describe('DOMSource.events()', function() {
 
     function app(sources: {DOM: DOMSource}) {
       return {
-        DOM: xs.of(div([div('.clickable', 'Hello')])),
+        DOM: xs.of(div('#bubpar',[div('.clickable', 'Hello')])),
       };
     }
 
@@ -572,7 +572,7 @@ describe('DOMSource.events()', function() {
 
     function app(sources: {DOM: DOMSource}) {
       return {
-        DOM: xs.of(div([div('.clickable', 'Hello')])),
+        DOM: xs.of(div('#bubpar',[div('.clickable', 'Hello')])),
       };
     }
 

--- a/dom/test/browser/src/render.tsx
+++ b/dom/test/browser/src/render.tsx
@@ -18,6 +18,7 @@ import {
   select,
   option,
   p,
+  footer,
   makeDOMDriver,
   DOMSource,
   MainDOMSource,
@@ -213,6 +214,31 @@ describe('DOM Rendering', function () {
         assert.notStrictEqual(selectEl, null);
         assert.notStrictEqual(typeof selectEl, 'undefined');
         assert.strictEqual(selectEl.tagName, 'SELECT');
+        setTimeout(() => {
+          dispose();
+          done();
+        });
+      },
+    });
+    dispose = run();
+  });
+
+  it('should not duplicate root element without ID', function (done) {
+    function app(sources: {DOM: MainDOMSource}) {
+      return {
+        DOM: xs.of(footer([h3('.my-class'),h3('.my-class')])),
+      };
+    }
+
+    const {sinks, sources, run} = setup(app, {
+      DOM: makeDOMDriver('footer'),
+    });
+    let dispose: any;
+    sources.DOM.select(':root').element().drop(1).take(1).addListener({
+      next: (root: Element) => {
+        assert.strictEqual(root.tagName, 'FOOTER');
+        assert.strictEqual(root.children.length, 2);
+        assert.strictEqual(root.children[0].tagName, 'H3');
         setTimeout(() => {
           dispose();
           done();


### PR DESCRIPTION
Do not duplicate the root element when not using ID property. For example, without this PR, when simply targeting the HEAD tag it gets duplicated because there is no associated ID. This PR simply gives the `selId` variable a default value of empty string, which correlate it with the default value of empty string given to the ID property of the `rootElement` object by `document.querySelector`.

- [x] There exists an issue discussing the need for this PR
- [x] I added new tests for the issue I fixed or built
- [ ] I used `make commit` instead of `git commit`

Discussions here: https://github.com/cyclejs/cyclejs/pull/792 https://github.com/cyclejs/cyclejs/issues/540

This fix broke two other tests:

```
DOMSource.events() should catch bubbling events in a DocumentFragment
DOMSource.events() should catch non-bubbling events in a DocumentFragment with useCapture
```
These tests worked before because the root tag was duplicated since there was no ID assigned to either the root element nor the parent VDOM object. After fixing the "duplicate bug" the root tag was no longer duplicated causing the tests to fail. 

```
...

return {
  DOM: xs.of(div([div('.clickable', 'Hello')])), // <-- no ID
};

...

const renderTarget = fragment.appendChild(document.createElement('div')); // <-- no ID
```
I added an ID to the root VDOM objects—now all tests pass.

```
...

return {
  DOM: xs.of(div('#bubpar',[div('.clickable', 'Hello')])), // <-- add ID 'bubpar'
};
```
Also, to get a working test I added a `<footer>` tag to the test index.html file, in order to be able to get a "clean" root element and parent VDOM object. My attempts to use `createRenderTarget` failed to test the fix, my guess is because dynamically adding a DOM object for the root element always created an (empty string) ID, rather than the needed `undefined`—and using the HEAD tag broke most tests.

Glad to be learning these tools so thanks for the guidance and let me know if I need to do anything different.