### PR TITLE
Update isomorphic example to use @cycle/html

### DIFF
--- a/examples/advanced/isomorphic/.babelrc
+++ b/examples/advanced/isomorphic/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015"]
+  "presets": ["env"]
 }

--- a/examples/advanced/isomorphic/app.js
+++ b/examples/advanced/isomorphic/app.js
@@ -32,9 +32,9 @@ function renderAboutPage() {
 }
 
 export default function app(sources) {
-  const click$ = sources.DOM.select('.link').events('click');
-
-  const preventedEvent$ = click$;
+  const click$ = sources.DOM.select('.link').events('click', {
+    preventDefault: true
+  });
 
   const contextFromClick$ = click$
     .map(ev => ({route: ev.currentTarget.attributes.href.value}));
@@ -54,7 +54,6 @@ export default function app(sources) {
     });
 
   return {
-    DOM: vdom$,
-    PreventDefault: preventedEvent$
+    DOM: vdom$
   };
 }

--- a/examples/advanced/isomorphic/client.js
+++ b/examples/advanced/isomorphic/client.js
@@ -9,14 +9,7 @@ function clientSideApp(sources) {
   return sinks;
 }
 
-function preventDefaultDriver(ev$) {
-  ev$.addListener({
-    next: ev => ev.preventDefault(),
-  });
-}
-
 run(clientSideApp, {
   DOM: makeDOMDriver('.app-container'),
   context: () => xs.of(window.appContext),
-  PreventDefault: preventDefaultDriver,
 });

--- a/examples/advanced/isomorphic/package.json
+++ b/examples/advanced/isomorphic/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "dependencies": {
     "@cycle/dom": "20.4.0",
+    "@cycle/html": "2.4.0",
     "@cycle/run": "4.1.0",
     "xstream": "11.2",
     "babel-cli": "^6.7.5",

--- a/examples/advanced/isomorphic/package.json
+++ b/examples/advanced/isomorphic/package.json
@@ -5,17 +5,17 @@
   "author": "Andre Staltz",
   "license": "MIT",
   "dependencies": {
-    "@cycle/dom": "15.0.0-rc.3",
-    "@cycle/run": "1.0.0-rc.9",
-    "xstream": "10.2",
+    "@cycle/dom": "20.4.0",
+    "@cycle/run": "4.1.0",
+    "xstream": "11.2",
     "babel-cli": "^6.7.5",
     "babel-preset-es2015": "^6.3.13",
     "babel-register": "^6.4.3",
-    "babelify": "^7.2.0",
-    "browserify": "13.0.x",
+    "babelify": "^8.0.0",
+    "browserify": "16.2.x",
     "express": "^4.12.3",
     "serialize-javascript": "^1.0.0",
-    "uglifyify": "^3.0.1"
+    "uglifyify": "^5.0.0"
   },
   "scripts": {
     "start": "npm install && babel-node ./server.js"

--- a/examples/advanced/isomorphic/package.json
+++ b/examples/advanced/isomorphic/package.json
@@ -9,7 +9,7 @@
     "@cycle/run": "4.1.0",
     "xstream": "11.2",
     "babel-cli": "^6.7.5",
-    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-env": "^1.7.0",
     "babel-register": "^6.4.3",
     "babelify": "^8.0.0",
     "browserify": "16.2.x",

--- a/examples/advanced/isomorphic/server.js
+++ b/examples/advanced/isomorphic/server.js
@@ -3,7 +3,8 @@ import xs from 'xstream';
 import express from 'express';
 import browserify from 'browserify';
 import serialize from 'serialize-javascript';
-import {html, head, title, body, div, script, makeHTMLDriver} from '@cycle/dom';
+import {html, head, title, body, div, script} from '@cycle/dom';
+import {makeHTMLDriver} from '@cycle/html';
 import app from './app';
 
 function wrapVTreeWithHTMLBoilerplate([vtree, context, clientBundle]) {

--- a/examples/advanced/isomorphic/server.js
+++ b/examples/advanced/isomorphic/server.js
@@ -73,7 +73,6 @@ server.use(function (req, res) {
   run(wrappedAppFn, {
     DOM: makeHTMLDriver(html => res.send(prependHTML5Doctype(html))),
     context: () => context$,
-    PreventDefault: () => {},
   });
 });
 


### PR DESCRIPTION
Deals with issue #686 

I have updated the isomorphic example to use the latest versions of its dependencies.
The updated isomorphic example uses makeHTMLDriver from @&#8203;cycle/html and the DOMSource.events preventDefault option.

- [x] There exists an issue discussing the need for this PR
- [ ] I added new tests for the issue I fixed or built
- [x] I used `make commit` instead of `git commit`
