### PR TITLE
chore(META): add path to local installed tsc

### DIFF
--- a/dom/yarn.lock
+++ b/dom/yarn.lock
@@ -764,7 +764,7 @@ snabbdom-jsx@^0.3.0:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/snabbdom-jsx/-/snabbdom-jsx-0.3.2.tgz#25044a03f59362d06d16eab22ed2767a54871596"
 
-snabbdom-selector@3:
+snabbdom-selector@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/snabbdom-selector/-/snabbdom-selector-3.0.0.tgz#787011a5e89e8b1fa2fb768d4bb52a84396714ec"
   dependencies:

--- a/time/package.json
+++ b/time/package.json
@@ -60,6 +60,6 @@
     "test-docs": "markdown-doctest",
     "browserify": "../node_modules/.bin/browserify lib/cjs/index.js --global-transform=browserify-shim --standalone CycleTime --exclude xstream --outfile dist/cycle-time.js",
     "minify": "node ../.scripts/minify.js dist/cycle-time.js dist/cycle-time.min.js",
-    "postlib": "tsc rxjs.ts most.ts --declaration --lib DOM,ES5,ES6"
+    "postlib": "../node_modules/.bin/tsc rxjs.ts most.ts --declaration --lib DOM,ES5,ES6"
   }
 }


### PR DESCRIPTION
This pr changed `tsc` command to pointed to the local installed the version. One doesn't install `tsc` globally will encounter an error `tsc: command not found`.

ran test `make test time` and committed using `make commit`.
