### PR TITLE
Update rxjs-run to use rxjs6

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "sinon": "1.17.7",
     "tempfile": "1.1.1",
     "testem": "1.18.4",
-    "ts-node": "3.3.0",
+    "ts-node": "6.1.1",
     "tsify": "3.0.3",
     "tslint": "5.8.0",
     "typescript": "2.5.3",

--- a/rxjs-run/package.json
+++ b/rxjs-run/package.json
@@ -38,7 +38,7 @@
     "@types/mocha": "2.2.x",
     "@types/node": "7.0.x",
     "@types/sinon": "1.16.x",
-    "rxjs": "5.5.x",
+    "rxjs": "6.2.x",
     "xstream": "11.x"
   },
   "engines": {

--- a/rxjs-run/package.json
+++ b/rxjs-run/package.json
@@ -31,14 +31,15 @@
   "types": "lib/cjs/index.d.ts",
   "dependencies": {
     "@cycle/run": "4.x",
-    "xstream": "*",
-    "rxjs": "*"
+    "rxjs": "*",
+    "xstream": "*"
   },
   "devDependencies": {
     "@types/mocha": "2.2.x",
     "@types/node": "7.0.x",
     "@types/sinon": "1.16.x",
     "rxjs": "6.2.x",
+    "symbol-observable": "^1.2.0",
     "xstream": "11.x"
   },
   "engines": {

--- a/rxjs-run/src/index.ts
+++ b/rxjs-run/src/index.ts
@@ -1,7 +1,5 @@
 import {Stream} from 'xstream';
-import {Observable} from 'rxjs/Observable';
-// tslint:disable-next-line:no-import-side-effect
-import 'rxjs/add/observable/from';
+import {from, Observable} from 'rxjs';
 import {setAdapt} from '@cycle/run/lib/adapt';
 import {
   setup as coreSetup,
@@ -18,7 +16,7 @@ export type Drivers<So extends Sources, Si extends Sinks> = {
 };
 
 setAdapt(function adaptXstreamToRx(stream: Stream<any>): Observable<any> {
-  return Observable.from(stream);
+  return from(stream);
 });
 
 /**

--- a/rxjs-run/test/index.ts
+++ b/rxjs-run/test/index.ts
@@ -1,4 +1,5 @@
 import 'mocha';
+import 'symbol-observable';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
 import {run, setup} from '../lib/cjs/index';
@@ -46,7 +47,8 @@ describe('setup', function() {
     function driver() {
       return of('b');
     }
-    let {sinks, sources} = setup(app, {other: driver});
+
+    const {sinks, sources} = setup(app, {other: driver});
     assert.strictEqual(typeof sinks, 'object');
     assert.strictEqual(typeof sinks.other.subscribe, 'function');
     assert.strictEqual(typeof sources, 'object');
@@ -69,7 +71,7 @@ describe('setup', function() {
         other: sources.other.pipe(take(1), startWith('a')),
       };
     }
-    function xsdriver(sink: Stream<string>): Stream<string> {
+    function xsdriver(): Stream<string> {
       return xs.of('b');
     }
 

--- a/rxjs-run/test/index.ts
+++ b/rxjs-run/test/index.ts
@@ -214,7 +214,7 @@ describe('run', function() {
       sinon.assert.calledOnce(console.error as any);
       sinon.assert.calledWithExactly(
         console.error as any,
-        sinon.match('malfunction'),
+        sinon.match((err: any) => err.message === 'malfunction'),
       );
 
       // Should be false because the error was already reported in the console.

--- a/rxjs-run/yarn.lock
+++ b/rxjs-run/yarn.lock
@@ -3,39 +3,39 @@
 
 
 "@cycle/run@4.x":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@cycle/run/-/run-4.0.0.tgz#d48c5133cd783afdf7f9e37ce1c158b570d6c5f1"
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@cycle/run/-/run-4.1.0.tgz#b164a83792e85db3c184236f4b3800a4c9bf6f76"
   dependencies:
     xstream "10.x || 11.x"
 
 "@types/mocha@2.2.x":
-  version "2.2.43"
-  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.43.tgz#03c54589c43ad048cbcbfd63999b55d0424eec27"
+  version "2.2.48"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.48.tgz#3523b126a0b049482e1c3c11877460f76622ffab"
 
 "@types/node@7.0.x":
-  version "7.0.46"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.46.tgz#c3dedd25558c676b3d6303e51799abb9c3f8f314"
+  version "7.0.66"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.66.tgz#3d1dc4d6f52e484e843806ff456379f7e6ad5553"
 
 "@types/sinon@1.16.x":
   version "1.16.36"
   resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-1.16.36.tgz#74bb6ed7928597c1b3fb1b009005e94dc6eae357"
 
-rxjs@^6.2.1:
+rxjs@6.2.x:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.2.1.tgz#246cebec189a6cbc143a3ef9f62d6f4c91813ca1"
   dependencies:
     tslib "^1.9.0"
 
-symbol-observable@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
+symbol-observable@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 
 tslib@^1.9.0:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.2.tgz#8be0cc9a1f6dc7727c38deb16c2ebd1a2892988e"
 
 "xstream@10.x || 11.x", xstream@11.x:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/xstream/-/xstream-11.0.0.tgz#2018c3c4e573f76b62b9cf96a17a46876ab120e0"
+  version "11.4.0"
+  resolved "https://registry.yarnpkg.com/xstream/-/xstream-11.4.0.tgz#e1b65693e36c3c60b3cf29f50d8d8e85954b91fd"
   dependencies:
-    symbol-observable "^1.0.4"
+    symbol-observable "1.2.0"

--- a/rxjs-run/yarn.lock
+++ b/rxjs-run/yarn.lock
@@ -26,7 +26,7 @@ rxjs@6.2.x:
   dependencies:
     tslib "^1.9.0"
 
-symbol-observable@1.2.0:
+symbol-observable@1.2.0, symbol-observable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 

--- a/rxjs-run/yarn.lock
+++ b/rxjs-run/yarn.lock
@@ -20,15 +20,19 @@
   version "1.16.36"
   resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-1.16.36.tgz#74bb6ed7928597c1b3fb1b009005e94dc6eae357"
 
-rxjs@5.5.x:
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.2.tgz#28d403f0071121967f18ad665563255d54236ac3"
+rxjs@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.2.1.tgz#246cebec189a6cbc143a3ef9f62d6f4c91813ca1"
   dependencies:
-    symbol-observable "^1.0.1"
+    tslib "^1.9.0"
 
-symbol-observable@^1.0.1, symbol-observable@^1.0.4:
+symbol-observable@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
+
+tslib@^1.9.0:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.2.tgz#8be0cc9a1f6dc7727c38deb16c2ebd1a2892988e"
 
 "xstream@10.x || 11.x", xstream@11.x:
   version "11.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -682,6 +682,10 @@ buffer-crc32@^0.2.1:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
 
+buffer-from@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.0.tgz#87fcaa3a298358e0ade6e442cfce840740d1ad04"
+
 buffer-shims@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
@@ -787,14 +791,6 @@ chalk@^0.5.1:
     has-ansi "^0.1.0"
     strip-ansi "^0.3.0"
     supports-color "^0.2.0"
-
-chalk@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.0.1.tgz#dbec49436d2ae15f536114e76d14656cdbc0f44d"
-  dependencies:
-    ansi-styles "^3.1.0"
-    escape-string-regexp "^1.0.5"
-    supports-color "^4.0.0"
 
 chalk@^2.1.0:
   version "2.3.0"
@@ -2451,7 +2447,7 @@ hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
-homedir-polyfill@^1.0.0, homedir-polyfill@^1.0.1:
+homedir-polyfill@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz#4c2bbc8a758998feebf5ed68580f76d46768b4bc"
   dependencies:
@@ -4573,13 +4569,14 @@ source-list-map@~0.1.7:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-0.1.8.tgz#c550b2ab5427f6b3f21f5afead88c4f5587b2106"
 
-source-map-support@^0.4.0:
-  version "0.4.14"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.14.tgz#9d4463772598b86271b4f523f6c1f4e02a7d6aef"
+source-map-support@^0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.6.tgz#4435cee46b1aab62b8e8610ce60f788091c51c13"
   dependencies:
-    source-map "^0.5.6"
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
 
-source-map@>=0.5.6, source-map@^0.5.1, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.3:
+source-map@>=0.5.6, source-map@^0.5.1, source-map@^0.5.3, source-map@~0.5.1, source-map@~0.5.3:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
@@ -4588,6 +4585,10 @@ source-map@^0.4.4, source-map@~0.4.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
   dependencies:
     amdefine ">=0.0.4"
+
+source-map@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
 source-map@~0.1.30:
   version "0.1.43"
@@ -4784,10 +4785,6 @@ strip-bom@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
   dependencies:
     is-utf8 "^0.2.0"
-
-strip-bom@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
 
 strip-indent@^1.0.1:
   version "1.0.1"
@@ -5041,19 +5038,16 @@ trim-off-newlines@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3"
 
-ts-node@3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-3.3.0.tgz#c13c6a3024e30be1180dd53038fc209289d4bf69"
+ts-node@6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-6.1.1.tgz#19607140acb06150441fcdb61be11f73f7b6657e"
   dependencies:
     arrify "^1.0.0"
-    chalk "^2.0.0"
     diff "^3.1.0"
     make-error "^1.1.1"
     minimist "^1.2.0"
     mkdirp "^0.5.1"
-    source-map-support "^0.4.0"
-    tsconfig "^6.0.0"
-    v8flags "^3.0.0"
+    source-map-support "^0.5.6"
     yn "^2.0.0"
 
 tsconfig@^5.0.3:
@@ -5063,13 +5057,6 @@ tsconfig@^5.0.3:
     any-promise "^1.3.0"
     parse-json "^2.2.0"
     strip-bom "^2.0.0"
-    strip-json-comments "^2.0.0"
-
-tsconfig@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/tsconfig/-/tsconfig-6.0.0.tgz#6b0e8376003d7af1864f8df8f89dd0059ffcd032"
-  dependencies:
-    strip-bom "^3.0.0"
     strip-json-comments "^2.0.0"
 
 tsify@3.0.3:
@@ -5250,12 +5237,6 @@ uuid@^2.0.1:
 uuid@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
-
-v8flags@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-3.0.1.tgz#dce8fc379c17d9f2c9e9ed78d89ce00052b1b76b"
-  dependencies:
-    homedir-polyfill "^1.0.1"
 
 validate-commit-msg@2.14.0:
   version "2.14.0"


### PR DESCRIPTION
This PR update rxjs-run to be able to use rxjs6.

- [x] There exists an issue discussing the need for this PR
- [ ] ~~I added new tests for the issue I fixed or built~~
- [x] I used `make commit` instead of `git commit`
- [x] Fix tests