### PR TITLE
fix(run): add two kinds of dispose() for setupReusable()

### DIFF
--- a/run/src/internals.ts
+++ b/run/src/internals.ts
@@ -124,8 +124,13 @@ export function replicateMany<Si extends Sinks>(
 
   return function disposeReplication() {
     subscriptions.forEach(s => s.unsubscribe());
-    sinkNames.forEach(name => sinkProxies[name]._c());
   };
+}
+
+export function disposeSinkProxies<Si extends Sinks>(
+  sinkProxies: SinkProxies<Si>,
+) {
+  Object.keys(sinkProxies).forEach(name => sinkProxies[name]._c());
 }
 
 export function disposeSources<So extends Sources>(sources: So) {

--- a/run/src/types.ts
+++ b/run/src/types.ts
@@ -49,4 +49,5 @@ export interface CycleProgram<So extends Sources, Si extends Sinks> {
 export interface Engine<So extends Sources, Si extends Sinks> {
   sources: So;
   run(sinks: Si): DisposeFunction;
+  dispose(): void;
 }


### PR DESCRIPTION
We should be able to dispose the reusable resources or dispose one specific run.

ISSUES CLOSED: #824

- [x] There exists an issue discussing the need for this PR
- [x] I added new tests for the issue I fixed or built
- [x] I used `make commit` instead of `git commit`
