### PR TITLE
fix(isolate): adapt sinks so xstream semantics can be applied

### DIFF
--- a/isolate/package.json
+++ b/isolate/package.json
@@ -30,12 +30,17 @@
   "module": "lib/es6/index.js",
   "typings": "lib/cjs/index.d.ts",
   "types": "lib/cjs/index.d.ts",
-  "dependencies": {},
+  "dependencies": {
+    "xstream": "^11.7.0",
+    "@cycle/run": "^4.4.0"
+  },
   "devDependencies": {
     "@types/mocha": "2.2.x",
     "@types/node": "7.0.x",
     "@types/sinon": "1.16.x",
-    "rxjs": "5.4.2"
+    "rxjs": "^6.2.1",
+    "@cycle/rxjs-run": "^9.1.0",
+    "symbol-observable": "*"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/isolate/src/index.ts
+++ b/isolate/src/index.ts
@@ -1,3 +1,5 @@
+import xs from 'xstream';
+import {adapt} from '@cycle/run/lib/adapt';
 export type Component<So, Si> = (sources: So, ...rest: Array<any>) => Si;
 
 export interface IsolateableSource {
@@ -102,7 +104,12 @@ function isolateAllSinks<So extends Sources, Si>(
       scopes[channel] !== null &&
       typeof source.isolateSink === 'function'
     ) {
-      outerSinks[channel] = source.isolateSink(innerSink, scopes[channel]);
+      outerSinks[channel] = adapt(
+        source.isolateSink(
+          xs.fromObservable(innerSink as any),
+          scopes[channel],
+        ),
+      );
     } else if (innerSinks.hasOwnProperty(channel)) {
       outerSinks[channel] = innerSinks[channel];
     }

--- a/isolate/test/index.ts
+++ b/isolate/test/index.ts
@@ -1,6 +1,8 @@
+import 'symbol-observable';
 import 'mocha';
+import '@cycle/rxjs-run';
 import * as assert from 'assert';
-import * as Rx from 'rxjs';
+import {of} from 'rxjs';
 import isolate from '../lib/cjs/index';
 import * as sinon from 'sinon';
 
@@ -45,7 +47,9 @@ describe('isolate', function() {
     assert.strictEqual(typeof scopedMyDataflowComponent, `function`);
   });
 
-  it('should accept a scopes-per-channel object as the second argument', function() {
+  it('should accept a scopes-per-channel object as the second argument', function(
+    done,
+  ) {
     function Component(sources: any) {
       return {
         first: sources.first.getSink(),
@@ -65,7 +69,7 @@ describe('isolate', function() {
     const sources = {
       first: {
         getSink() {
-          return 10;
+          return of(10);
         },
         isolateSource(source: any, scope: string) {
           actual1 = scope;
@@ -79,7 +83,7 @@ describe('isolate', function() {
 
       second: {
         getSink() {
-          return 20;
+          return of(20);
         },
         isolateSource(source: any, scope: string) {
           actual3 = scope;
@@ -97,11 +101,16 @@ describe('isolate', function() {
     assert.strictEqual(actual2, 'scope1');
     assert.strictEqual(actual3, 'scope2');
     assert.strictEqual(actual4, 'scope2');
-    assert.strictEqual(sinks.first, 10);
-    assert.strictEqual(sinks.second, 20);
+    sinks.first.subscribe((x: any) => {
+      assert.strictEqual(x, 10);
+    });
+    sinks.second.subscribe((x: any) => {
+      assert.strictEqual(x, 20);
+      done();
+    });
   });
 
-  it('should not isolate a channel given null scope', function() {
+  it('should not isolate a channel given null scope', function(done) {
     function Component(sources: any) {
       return {
         first: sources.first.getSink(),
@@ -121,7 +130,7 @@ describe('isolate', function() {
     const sources = {
       first: {
         getSink() {
-          return 10;
+          return of(10);
         },
         isolateSource(source: any, scope: string) {
           actual1 = scope;
@@ -135,7 +144,7 @@ describe('isolate', function() {
 
       second: {
         getSink() {
-          return 20;
+          return of(20);
         },
         isolateSource(source: any, scope: string) {
           actual3 = scope;
@@ -153,11 +162,18 @@ describe('isolate', function() {
     assert.strictEqual(actual2, '');
     assert.strictEqual(actual3, 'scope2');
     assert.strictEqual(actual4, 'scope2');
-    assert.strictEqual(sinks.first, 10);
-    assert.strictEqual(sinks.second, 20);
+    sinks.first.subscribe((x: any) => {
+      assert.strictEqual(x, 10);
+    });
+    sinks.second.subscribe((x: any) => {
+      assert.strictEqual(x, 20);
+      done();
+    });
   });
 
-  it('should generate a scope if a channel is undefined in scopes-per-channel', function() {
+  it('should generate a scope if a channel is undefined in scopes-per-channel', function(
+    done,
+  ) {
     function Component(sources: any) {
       return {
         first: sources.first.getSink(),
@@ -174,7 +190,7 @@ describe('isolate', function() {
     const sources = {
       first: {
         getSink() {
-          return 10;
+          return of(10);
         },
         isolateSource(source: any, scope: string) {
           actual1 = scope;
@@ -188,7 +204,7 @@ describe('isolate', function() {
 
       second: {
         getSink() {
-          return 20;
+          return of(20);
         },
         isolateSource(source: any, scope: string) {
           actual3 = scope;
@@ -206,11 +222,18 @@ describe('isolate', function() {
     assert.strictEqual(actual2, 'scope1');
     assert.strictEqual(actual3, 'cycle1');
     assert.strictEqual(actual4, 'cycle1');
-    assert.strictEqual(sinks.first, 10);
-    assert.strictEqual(sinks.second, 20);
+    sinks.first.subscribe((x: any) => {
+      assert.strictEqual(x, 10);
+    });
+    sinks.second.subscribe((x: any) => {
+      assert.strictEqual(x, 20);
+      done();
+    });
   });
 
-  it('should accept a wildcard * in the scopes-per-channel object', function() {
+  it('should accept a wildcard * in the scopes-per-channel object', function(
+    done,
+  ) {
     function Component(sources: any) {
       return {
         first: sources.first.getSink(),
@@ -230,7 +253,7 @@ describe('isolate', function() {
     const sources = {
       first: {
         getSink() {
-          return 10;
+          return of(10);
         },
         isolateSource(source: any, scope: string) {
           actual1 = scope;
@@ -244,7 +267,7 @@ describe('isolate', function() {
 
       second: {
         getSink() {
-          return 20;
+          return of(20);
         },
         isolateSource(source: any, scope: string) {
           actual3 = scope;
@@ -262,11 +285,18 @@ describe('isolate', function() {
     assert.strictEqual(actual2, 'scope1');
     assert.strictEqual(actual3, 'default');
     assert.strictEqual(actual4, 'default');
-    assert.strictEqual(sinks.first, 10);
-    assert.strictEqual(sinks.second, 20);
+    sinks.first.subscribe((x: any) => {
+      assert.strictEqual(x, 10);
+    });
+    sinks.second.subscribe((x: any) => {
+      assert.strictEqual(x, 20);
+      done();
+    });
   });
 
-  it('should not isolate a non-specified channel if wildcard * is null', function() {
+  it('should not isolate a non-specified channel if wildcard * is null', function(
+    done,
+  ) {
     function Component(sources: any) {
       return {
         first: sources.first.getSink(),
@@ -286,7 +316,7 @@ describe('isolate', function() {
     const sources = {
       first: {
         getSink() {
-          return 10;
+          return of(10);
         },
         isolateSource(source: any, scope: string) {
           actual1 = scope;
@@ -300,7 +330,7 @@ describe('isolate', function() {
 
       second: {
         getSink() {
-          return 20;
+          return of(20);
         },
         isolateSource(source: any, scope: string) {
           actual3 = scope;
@@ -318,11 +348,18 @@ describe('isolate', function() {
     assert.strictEqual(actual2, 'scope1');
     assert.strictEqual(actual3, '');
     assert.strictEqual(actual4, '');
-    assert.strictEqual(sinks.first, 10);
-    assert.strictEqual(sinks.second, 20);
+    sinks.first.subscribe((x: any) => {
+      assert.strictEqual(x, 10);
+    });
+    sinks.second.subscribe((x: any) => {
+      assert.strictEqual(x, 20);
+      done();
+    });
   });
 
-  it('should not convert to string values in scopes-per-channel object', function() {
+  it('should not convert to string values in scopes-per-channel object', function(
+    done,
+  ) {
     function Component(sources: any) {
       return {
         first: sources.first.getSink(),
@@ -339,7 +376,7 @@ describe('isolate', function() {
     const sources = {
       first: {
         getSink() {
-          return 10;
+          return of(10);
         },
         isolateSource(source: any, scope: string) {
           actual1 = scope;
@@ -353,7 +390,7 @@ describe('isolate', function() {
 
       second: {
         getSink() {
-          return 20;
+          return of(20);
         },
         isolateSource(source: any, scope: string) {
           actual3 = scope;
@@ -371,12 +408,17 @@ describe('isolate', function() {
     assert.strictEqual(actual2, 123);
     assert.strictEqual(actual3, 456);
     assert.strictEqual(actual4, 456);
-    assert.strictEqual(sinks.first, 10);
-    assert.strictEqual(sinks.second, 20);
+    sinks.first.subscribe((x: any) => {
+      assert.strictEqual(x, 10);
+    });
+    sinks.second.subscribe((x: any) => {
+      assert.strictEqual(x, 20);
+      done();
+    });
   });
 
   describe('scopedDataflowComponent', function() {
-    it('should return a valid dataflow component', function() {
+    it('should return a valid dataflow component', function(done) {
       function driver() {
         return {};
       }
@@ -387,7 +429,7 @@ describe('isolate', function() {
         bar: string,
       ) {
         return {
-          other: Rx.Observable.of([foo, bar]),
+          other: of([foo, bar]),
         };
       }
       const scopedMyDataflowComponent = isolate(MyDataflowComponent);
@@ -400,6 +442,7 @@ describe('isolate', function() {
       assert.strictEqual(typeof scopedSinks, `object`);
       scopedSinks.other.subscribe((x: Array<string>) => {
         assert.strictEqual(x.join(), `foo,bar`);
+        done();
       });
     });
 
@@ -440,7 +483,7 @@ describe('isolate', function() {
 
       function MyDataflowComponent(sources: {other: any}) {
         return {
-          other: ['a'],
+          other: of(['a']),
         };
       }
       let scopedMyDataflowComponent;
@@ -450,11 +493,12 @@ describe('isolate', function() {
       const scopedSinks = (scopedMyDataflowComponent as any)({
         other: driver(null),
       });
-      assert.strictEqual(scopedSinks.other.length, 1);
-      assert.strictEqual(scopedSinks.other[0], 'a');
+      scopedSinks.other.subscribe((x: any) =>
+        assert.strictEqual(x, 'a myScope'),
+      );
     });
 
-    it('should call `isolateSink` of drivers', function() {
+    it('should call `isolateSink` of drivers', function(done) {
       function driver() {
         function isolateSink(sink: any, scope: string) {
           return sink.map((v: string) => `${v} ${scope}`);
@@ -466,13 +510,15 @@ describe('isolate', function() {
 
       function MyDataflowComponent(sources: {other: any}) {
         return {
-          other: ['a'],
+          other: of(['a']),
         };
       }
       const scopedMyDataflowComponent = isolate(MyDataflowComponent, `myScope`);
       const scopedSinks = scopedMyDataflowComponent({other: driver()});
-      assert.strictEqual(scopedSinks.other.length, 1);
-      assert.strictEqual(scopedSinks.other[0], `a myScope`);
+      scopedSinks.other.subscribe((x: any) => {
+        assert.strictEqual(x, 'a myScope');
+        done();
+      });
     });
 
     it('should handle undefined cases gracefully', function() {

--- a/isolate/yarn.lock
+++ b/isolate/yarn.lock
@@ -2,6 +2,22 @@
 # yarn lockfile v1
 
 
+"@cycle/run@4.x", "@cycle/run@^4.4.0":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@cycle/run/-/run-4.4.0.tgz#8013702548b1992f665b9f2f42882996871ccf8f"
+  dependencies:
+    quicktask "1.1.0"
+    xstream "10.x || 11.x"
+
+"@cycle/rxjs-run@^9.1.0":
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/@cycle/rxjs-run/-/rxjs-run-9.1.0.tgz#8a49fef7e6d993525a7a673fc89f590ffe404ffc"
+  dependencies:
+    "@cycle/run" "4.x"
+    rxjs "^6.0.0"
+    symbol-observable "^1.2.0"
+    xstream "11.x"
+
 "@types/mocha@2.2.x":
   version "2.2.40"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.40.tgz#9811dd800ece544cd84b5b859917bf584a150c4c"
@@ -14,12 +30,26 @@
   version "1.16.36"
   resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-1.16.36.tgz#74bb6ed7928597c1b3fb1b009005e94dc6eae357"
 
-rxjs@5.4.2:
-  version "5.4.2"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.4.2.tgz#2a3236fcbf03df57bae06fd6972fd99e5c08fcf7"
-  dependencies:
-    symbol-observable "^1.0.1"
+quicktask@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/quicktask/-/quicktask-1.1.0.tgz#70795fd5922fb122100e662118c73a06aadd7352"
 
-symbol-observable@^1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
+rxjs@^6.0.0, rxjs@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.2.1.tgz#246cebec189a6cbc143a3ef9f62d6f4c91813ca1"
+  dependencies:
+    tslib "^1.9.0"
+
+symbol-observable@*, symbol-observable@1.2.0, symbol-observable@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+
+tslib@^1.9.0:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+
+"xstream@10.x || 11.x", xstream@11.x, xstream@^11.7.0:
+  version "11.7.0"
+  resolved "https://registry.yarnpkg.com/xstream/-/xstream-11.7.0.tgz#6557e9710e1ab05ae28b6902af41745250d32e36"
+  dependencies:
+    symbol-observable "1.2.0"


### PR DESCRIPTION
Rxjs 6 uses a piping semantic which removes the existence of the map prototype from the base
Observable class, this change ensures that each sink stream is adapted to xstream before
isolation
operations are applied.

BREAKING CHANGE:
This update changes the contract such that xstream and @cycle/run are now dependencies.

ISSUES CLOSED: #826

<!--
Thank you for your contribution!
To help speed up the process of merging your code, check the following:
-->

- [x] There exists an issue discussing the need for this PR
- [x] I added new tests for the issue I fixed or built
- [x] I used `make commit` instead of `git commit`
