### PR TITLE
WIP use TypeScript `unknown` in isolate

### DIFF
--- a/dom/package.json
+++ b/dom/package.json
@@ -55,7 +55,7 @@
     "xstream": "*"
   },
   "devDependencies": {
-    "@cycle/isolate": "^4.1.0",
+    "@cycle/isolate": "^5.0.0",
     "@cycle/rxjs-run": "^10.2.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.12.11",

--- a/html/package.json
+++ b/html/package.json
@@ -41,7 +41,7 @@
     "xstream": "*"
   },
   "devDependencies": {
-    "@cycle/isolate": "^4.2.0",
+    "@cycle/isolate": "^5.0.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.12.11",
     "@types/sinon": "^5.0.7",

--- a/http/package.json
+++ b/http/package.json
@@ -31,7 +31,7 @@
     "xstream": "*"
   },
   "devDependencies": {
-    "@cycle/isolate": "^4.2.0",
+    "@cycle/isolate": "^5.0.0",
     "@cycle/rxjs-run": "^10.2.0",
     "@types/body-parser": "1.17.x",
     "@types/cookie-parser": "1.4.x",

--- a/isolate/CHANGELOG.md
+++ b/isolate/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 5.0.0 (2019-02-03)
+
+* fix(isolate): use TypeScript unknown to force casting types ([ff698ce](https://github.com/cyclejs/cyclejs/commit/ff698ce))
+
+
+### BREAKING CHANGE
+
+* If you use JavaScript, there are no breaking changes. If you use
+TypeScript, then from now onwards isolate() returns sink types that are
+never type "any", but instead returns "unknown". Often it may infer the
+correct type, but when it cannot infer the type, it will return
+"unknown" which means you are forced to type cast it to the correct
+type. This is better than "any", because "any" is like JavaScript and
+gives little type safety.
+
+
 ## 4.2.0 (2018-12-10)
 
 * fix(isolate): support TypeScript's strict mode ([c8aee41](https://github.com/cyclejs/cyclejs/commit/c8aee41))

--- a/isolate/package.json
+++ b/isolate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cycle/isolate",
-  "version": "4.2.0",
+  "version": "5.0.0",
   "description": "A utility function to make scoped dataflow components in Cycle.js",
   "license": "MIT",
   "homepage": "https://cycle.js.org",

--- a/isolate/src/index.ts
+++ b/isolate/src/index.ts
@@ -135,13 +135,17 @@ function isolateAllSinks<So extends Sources, Si>(
 
 export type OuterSo<ISo> = {
   [K in keyof ISo]: ISo[K] extends IsolateableSource
-    ? any //FirstArg<IsolateableSource['isolateSource']>
+    ? FirstArg<IsolateableSource['isolateSource']>
     : ISo[K]
 };
 
 export type OuterSi<ISo, ISi> = {
   [K in keyof ISo & keyof ISi]: ISo[K] extends IsolateableSource
-    ? any // ReturnType<ISo[K]['isolateSink']>   <- This does not work for e.g. @cycle/state
+    ? (ReturnType<ISo[K]['isolateSink']> extends Stream<infer T>
+        ? Stream<T>
+        : (ReturnType<ISo[K]['isolateSink']> extends Stream<any>
+            ? Stream<unknown>
+            : unknown))
     : ISi[K]
 } &
   {[K in Exclude<keyof ISi, keyof ISo>]: ISi[K]};

--- a/isolate/test/index.ts
+++ b/isolate/test/index.ts
@@ -440,7 +440,7 @@ describe('isolate', function() {
       }
 
       function MyDataflowComponent(
-        sources: {other: any},
+        sources: {other: unknown},
         foo: string,
         bar: string
       ) {
@@ -456,8 +456,8 @@ describe('isolate', function() {
       );
 
       assert.strictEqual(typeof scopedSinks, `object`);
-      scopedSinks.other.subscribe((x: Array<string>) => {
-        assert.strictEqual(x.join(), `foo,bar`);
+      scopedSinks.other.subscribe(strings => {
+        assert.strictEqual(strings.join(), `foo,bar`);
         done();
       });
     });
@@ -492,11 +492,11 @@ describe('isolate', function() {
         {other: new MyTestSource()},
         `foo`,
         `bar`
-      );
+      ) as {other: Observable<Array<string>>};
 
       assert.strictEqual(typeof scopedSinks, `object`);
-      scopedSinks.other.subscribe((x: Array<string>) => {
-        assert.strictEqual(x.join(), `foo,bar`);
+      scopedSinks.other.subscribe(strings => {
+        assert.strictEqual(strings.join(), `foo,bar`);
         done();
       });
     });
@@ -531,11 +531,11 @@ describe('isolate', function() {
         {other: new MyTestSource()},
         `foo`,
         `bar`
-      );
+      ) as {other: Observable<Array<number>>};
 
       assert.strictEqual(typeof scopedSinks, `object`);
-      scopedSinks.other.subscribe((x: Array<number>) => {
-        assert.strictEqual(x.join(), `123,456`);
+      scopedSinks.other.subscribe(nums => {
+        assert.strictEqual(nums.join(), `123,456`);
         done();
       });
     });
@@ -624,7 +624,7 @@ describe('isolate', function() {
         };
       }
 
-      function MyDataflowComponent(sources: {other: any}) {
+      function MyDataflowComponent(sources: {other: unknown}) {
         return {
           other: of('a'),
         };
@@ -632,7 +632,7 @@ describe('isolate', function() {
       const scopedMyDataflowComponent = isolate(MyDataflowComponent, `myScope`);
       const scopedSinks = scopedMyDataflowComponent({other: driver()});
       const i = 0;
-      scopedSinks.other.subscribe((x: any) => {
+      scopedSinks.other.subscribe(x => {
         assert.strictEqual(x, 'a myScope');
         done();
       });

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -183,7 +183,7 @@ importers:
       superagent: 3.8.3
       xstream: 11.10.0
     devDependencies:
-      '@cycle/isolate': 4.2.0
+      '@cycle/isolate': 5.0.0
       '@cycle/rxjs-run': 10.2.0
       '@types/body-parser': 1.17.0
       '@types/cookie-parser': 1.4.1
@@ -207,7 +207,7 @@ importers:
       tslint: /tslint/5.12.1/typescript@3.2.4
       typescript: 3.2.4
     specifiers:
-      '@cycle/isolate': ^4.2.0
+      '@cycle/isolate': ^5.0.0
       '@cycle/run': ^5.2.0
       '@cycle/rxjs-run': ^10.2.0
       '@types/body-parser': 1.17.x
@@ -448,7 +448,6 @@ packages:
     dependencies:
       '@cycle/run': 5.2.0
       xstream: 11.10.0
-    dev: false
     engines:
       node: '>=0.10.0'
     resolution:

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -37,10 +37,10 @@ importers:
       snabbdom-selector: 4.1.0
       xstream: 11.10.0
     devDependencies:
-      '@cycle/isolate': 4.2.0
+      '@cycle/isolate': 5.0.0
       '@cycle/rxjs-run': 10.2.0
       '@types/mocha': 5.2.5
-      '@types/node': 10.12.18
+      '@types/node': 10.12.21
       '@types/sinon': 5.0.7
       deepmerge: 2.2.1
       es6-map: 0.1.5
@@ -50,20 +50,20 @@ importers:
       karma-chrome-launcher: 2.2.0
       karma-firefox-launcher: 1.1.0
       karma-mocha: 1.3.0
-      karma-typescript: /karma-typescript/3.0.13/karma@3.1.4+typescript@3.2.4
+      karma-typescript: /karma-typescript/3.0.13/karma@3.1.4+typescript@3.3.1
       mocha: 5.2.0
       most: /most/1.7.3/most@1.7.3
       mutation-observer: 1.0.3
-      rxjs: 6.3.3
+      rxjs: 6.4.0
       simulant: 0.2.2
       sinon: 7.2.3
       snabbdom-pragma: 2.8.0
       symbol-observable: 1.2.0
       ts-node: 7.0.1
-      tslint: /tslint/5.12.1/typescript@3.2.4
-      typescript: 3.2.4
+      tslint: /tslint/5.12.1/typescript@3.3.1
+      typescript: 3.3.1
     specifiers:
-      '@cycle/isolate': ^4.1.0
+      '@cycle/isolate': ^5.0.0
       '@cycle/run': ^5.2.0
       '@cycle/rxjs-run': ^10.2.0
       '@types/mocha': ^5.2.5
@@ -435,15 +435,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-7VMGsiQsHp8cHD+o3HcuOrvHkTlS7TY1aNyLoEJD0p5cWmxzaiotapFH+6rDpNq4FzuiIeZLR5SPHVNEt9pBQA==
-  /@cycle/isolate/4.2.0:
-    dependencies:
-      '@cycle/run': 5.2.0
-      xstream: 11.10.0
-    dev: true
-    engines:
-      node: '>=0.10.0'
-    resolution:
-      integrity: sha512-I11AOSaKIIuh5Ww08BRO9pZiqi5HxtQUM2eFMOAkwDyjlLfuzqvZKSg61NWJfl/RPAgcMwgDo1tbExSr3nI+NA==
   /@cycle/isolate/5.0.0:
     dependencies:
       '@cycle/run': 5.2.0
@@ -1617,12 +1608,12 @@ packages:
       node: '>=0.6'
     resolution:
       integrity: sha512-d5AT9lMTYJ/ZE/4gzxb+5ttPcRWljVsvv7lF1w9KzkPhVUhBtHrjDo1J8swfZKepfLsliDhYa31zRYwcD0Yg9w==
-  /binary-extensions/1.12.0:
+  /binary-extensions/1.13.0:
     dev: true
     engines:
       node: '>=0.10.0'
     resolution:
-      integrity: sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==
+      integrity: sha512-EgmjVLMn22z7eGGv3kcnHwSnJXmFHjISTY9E/S5lIcTD3Oxw05QTcBLNkJFzcb3cNueUdF/IN4U+d78V0zO8Hw==
   /binary/0.3.0:
     dependencies:
       buffers: 0.1.1
@@ -4346,7 +4337,7 @@ packages:
       integrity: sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
   /is-binary-path/1.0.1:
     dependencies:
-      binary-extensions: 1.12.0
+      binary-extensions: 1.13.0
     dev: true
     engines:
       node: '>=0.10.0'
@@ -4877,6 +4868,57 @@ packages:
       tmp: 0.0.29
       tty-browserify: 0.0.0
       typescript: 3.2.4
+      url: 0.11.0
+      util: 0.10.4
+      vm-browserify: 0.0.4
+    dev: true
+    id: registry.npmjs.org/karma-typescript/3.0.13
+    peerDependencies:
+      karma: 1 || 2
+      typescript: '2'
+    resolution:
+      integrity: sha1-iUivvRA6wZh6WWGg9DoboocQZ80=
+  /karma-typescript/3.0.13/karma@3.1.4+typescript@3.3.1:
+    dependencies:
+      acorn: 4.0.13
+      assert: 1.4.1
+      async: 2.6.1
+      browser-resolve: 1.11.3
+      browserify-zlib: 0.2.0
+      buffer: 5.2.1
+      combine-source-map: 0.8.0
+      console-browserify: 1.1.0
+      constants-browserify: 1.0.0
+      convert-source-map: 1.6.0
+      crypto-browserify: 3.12.0
+      diff: 3.5.0
+      domain-browser: 1.2.0
+      events: 1.1.1
+      glob: 7.1.3
+      https-browserify: 1.0.0
+      istanbul: 0.4.5
+      json-stringify-safe: 5.0.1
+      karma: 3.1.4
+      karma-coverage: 1.1.2
+      lodash: 4.17.11
+      log4js: 1.1.1
+      minimatch: 3.0.4
+      os-browserify: 0.3.0
+      pad: 2.2.2
+      path-browserify: 0.0.0
+      process: 0.11.10
+      punycode: 1.4.1
+      querystring-es3: 0.2.1
+      readable-stream: 2.3.6
+      remap-istanbul: 0.10.1
+      source-map: 0.6.1
+      stream-browserify: 2.0.2
+      stream-http: 2.8.3
+      string_decoder: 1.2.0
+      timers-browserify: 2.0.10
+      tmp: 0.0.29
+      tty-browserify: 0.0.0
+      typescript: 3.3.1
       url: 0.11.0
       util: 0.10.4
       vm-browserify: 0.0.4
@@ -5453,7 +5495,7 @@ packages:
       loud-rejection: 1.6.0
       map-obj: 1.0.1
       minimist: 1.2.0
-      normalize-package-data: 2.4.0
+      normalize-package-data: 2.4.2
       object-assign: 4.1.1
       read-pkg-up: 1.0.1
       redent: 1.0.0
@@ -5766,6 +5808,15 @@ packages:
     dev: true
     resolution:
       integrity: sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==
+  /normalize-package-data/2.4.2:
+    dependencies:
+      hosted-git-info: 2.7.1
+      is-builtin-module: 1.0.0
+      semver: 5.6.0
+      validate-npm-package-license: 3.0.4
+    dev: true
+    resolution:
+      integrity: sha512-YcMnjqeoUckXTPKZSAsPjUPLxH85XotbpqK3w4RyCwdFQSU5FxxBys8buehkSfg0j9fKvV1hn7O0+8reEgkAiw==
   /normalize-path/2.1.1:
     dependencies:
       remove-trailing-separator: 1.1.0
@@ -6544,7 +6595,7 @@ packages:
   /read-pkg/1.1.0:
     dependencies:
       load-json-file: 1.1.0
-      normalize-package-data: 2.4.0
+      normalize-package-data: 2.4.2
       path-type: 1.1.0
     dev: true
     engines:
@@ -6889,6 +6940,14 @@ packages:
       npm: '>=2.0.0'
     resolution:
       integrity: sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==
+  /rxjs/6.4.0:
+    dependencies:
+      tslib: 1.9.3
+    dev: true
+    engines:
+      npm: '>=2.0.0'
+    resolution:
+      integrity: sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==
   /safe-buffer/5.1.2:
     resolution:
       integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -7825,6 +7884,30 @@ packages:
       typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev'
     resolution:
       integrity: sha512-sfodBHOucFg6egff8d1BvuofoOQ/nOeYNfbp7LDlKBcLNrL3lmS5zoiDGyOMdT7YsEXAwWpTdAHwOGOc8eRZAw==
+  /tslint/5.12.1/typescript@3.3.1:
+    dependencies:
+      babel-code-frame: 6.26.0
+      builtin-modules: 1.1.1
+      chalk: 2.4.2
+      commander: 2.19.0
+      diff: 3.5.0
+      glob: 7.1.3
+      js-yaml: 3.12.1
+      minimatch: 3.0.4
+      resolve: 1.10.0
+      semver: 5.6.0
+      tslib: 1.9.3
+      tsutils: /tsutils/2.29.0/typescript@3.3.1
+      typescript: 3.3.1
+    dev: true
+    engines:
+      node: '>=4.8.0'
+    hasBin: true
+    id: registry.npmjs.org/tslint/5.12.1
+    peerDependencies:
+      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev'
+    resolution:
+      integrity: sha512-sfodBHOucFg6egff8d1BvuofoOQ/nOeYNfbp7LDlKBcLNrL3lmS5zoiDGyOMdT7YsEXAwWpTdAHwOGOc8eRZAw==
   /tsutils/2.29.0:
     dependencies:
       tslib: 1.9.3
@@ -7837,6 +7920,16 @@ packages:
     dependencies:
       tslib: 1.9.3
       typescript: 3.2.4
+    dev: true
+    id: registry.npmjs.org/tsutils/2.29.0
+    peerDependencies:
+      typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
+    resolution:
+      integrity: sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
+  /tsutils/2.29.0/typescript@3.3.1:
+    dependencies:
+      tslib: 1.9.3
+      typescript: 3.3.1
     dev: true
     id: registry.npmjs.org/tsutils/2.29.0
     peerDependencies:
@@ -7892,6 +7985,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
+  /typescript/3.3.1:
+    dev: true
+    engines:
+      node: '>=4.2.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-cTmIDFW7O0IHbn1DPYjkiebHxwtCMU+eTy30ZtJNBPF9j2O1ITu5XH2YnBeVRKWHqF+3JQwWJv0Q0aUgX8W7IA==
   /uc.micro/1.0.5:
     dev: true
     resolution:

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -146,9 +146,9 @@ importers:
       snabbdom-to-html: 5.1.1
       xstream: 11.10.0
     devDependencies:
-      '@cycle/isolate': 4.2.0
+      '@cycle/isolate': 5.0.0
       '@types/mocha': 5.2.5
-      '@types/node': 10.12.18
+      '@types/node': 10.12.21
       '@types/sinon': 5.0.7
       mocha: 5.2.0
       simulant: 0.2.2
@@ -159,7 +159,7 @@ importers:
       typescript: 3.2.4
     specifiers:
       '@cycle/dom': ^22.2.0
-      '@cycle/isolate': ^4.2.0
+      '@cycle/isolate': ^5.0.0
       '@cycle/run': ^5.2.0
       '@types/mocha': ^5.2.5
       '@types/node': ^10.12.11
@@ -428,7 +428,7 @@ packages:
   /@cycle/dom/22.3.0:
     dependencies:
       '@cycle/run': 5.2.0
-      snabbdom: 0.7.3
+      snabbdom: 0.7.2
       snabbdom-selector: 4.1.0
       xstream: 11.10.0
     engines:
@@ -7099,7 +7099,6 @@ packages:
     resolution:
       integrity: sha512-rz/Q8nh2RiY9echnpQdIQpGsvqPyjfEcFZ636tlggw59WlcsRrWfctYIVlGHZxUzcX025lw69oTCqceGdeXoGg==
   /snabbdom/0.7.2:
-    dev: false
     resolution:
       integrity: sha512-rDY283fYUB/3z2tjXsRRccsbVJqmGLtP+iI1tfa1DDHo2xZ49cq1leq9JmYyvZQhESuYJRY/is6WYhP2UuiRVg==
   /snabbdom/0.7.3:

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -346,14 +346,14 @@ importers:
       xstream: '*'
   state:
     dependencies:
-      '@cycle/isolate': 4.2.0
+      '@cycle/isolate': 5.0.0
       '@cycle/run': 5.2.0
       quicktask: 1.1.0
       xstream: 11.10.0
     devDependencies:
       '@cycle/rxjs-run': 10.2.0
       '@types/mocha': 5.2.5
-      '@types/node': 10.12.18
+      '@types/node': 10.12.21
       '@types/sinon': 5.0.7
       mocha: 5.2.0
       most: /most/1.7.3/most@1.7.3
@@ -362,7 +362,7 @@ importers:
       tslint: /tslint/5.12.1/typescript@3.2.4
       typescript: 3.2.4
     specifiers:
-      '@cycle/isolate': ^4.2.0
+      '@cycle/isolate': ^5.0.0
       '@cycle/run': ^5.2.0
       '@cycle/rxjs-run': ^10.2.0
       '@types/mocha': 5.2.x
@@ -439,10 +439,20 @@ packages:
     dependencies:
       '@cycle/run': 5.2.0
       xstream: 11.10.0
+    dev: true
     engines:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-I11AOSaKIIuh5Ww08BRO9pZiqi5HxtQUM2eFMOAkwDyjlLfuzqvZKSg61NWJfl/RPAgcMwgDo1tbExSr3nI+NA==
+  /@cycle/isolate/5.0.0:
+    dependencies:
+      '@cycle/run': 5.2.0
+      xstream: 11.10.0
+    dev: false
+    engines:
+      node: '>=0.10.0'
+    resolution:
+      integrity: sha512-9MS+Z7AjRzYljOc+AqSQUQBmQw0473rqv6op0dyhumILydcGirTmR6hrilJ/IYcYjeDEYaVfftYuIu15kU/Qcg==
   /@cycle/run/5.2.0:
     dependencies:
       quicktask: 1.1.0
@@ -574,6 +584,10 @@ packages:
   /@types/node/10.12.18:
     resolution:
       integrity: sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==
+  /@types/node/10.12.21:
+    dev: true
+    resolution:
+      integrity: sha512-CBgLNk4o3XMnqMc0rhb6lc77IwShMEglz05deDcn2lQxyXEZivfwgYJu7SMha9V5XcrP6qZuevTHV/QrN2vjKQ==
   /@types/range-parser/1.2.3:
     dev: true
     resolution:

--- a/state/CHANGELOG.md
+++ b/state/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.0 (2019-02-03)
+
+* fix(state): depend on cycle/isolate v5 ([5db111c](https://github.com/cyclejs/cyclejs/commit/5db111c))
+
+
+
 ## 1.1.0 (2018-12-10)
 
 * fix(state): support TypeScript's strict mode ([4b7bbeb](https://github.com/cyclejs/cyclejs/commit/4b7bbeb))

--- a/state/package.json
+++ b/state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cycle/state",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Wraps your Cycle.js main function with reducer-driven state management",
   "license": "MIT",
   "homepage": "https://cycle.js.org",

--- a/state/package.json
+++ b/state/package.json
@@ -27,7 +27,7 @@
   "typings": "lib/cjs/index.d.ts",
   "types": "lib/cjs/index.d.ts",
   "dependencies": {
-    "@cycle/isolate": "^4.2.0",
+    "@cycle/isolate": "^5.0.0",
     "@cycle/run": "^5.2.0",
     "quicktask": "1.1.0",
     "xstream": ">=11"

--- a/state/test/withState.ts
+++ b/state/test/withState.ts
@@ -142,7 +142,7 @@ describe('withState', function() {
     function Parent(sources: ParentSources): ParentSinks {
       const childSinks = isolate(Child, {state: 'child'})(sources);
       return {
-        state: childSinks.state,
+        state: childSinks.state as Stream<Reducer<Parent>>,
       };
     }
   });
@@ -450,7 +450,7 @@ describe('withState', function() {
 
     function main(sources: {state: StateSource<any>}) {
       const childSinks = isolate(child, 'child')(sources);
-      const childReducer$ = childSinks.state;
+      const childReducer$ = childSinks.state as Stream<Reducer<any>>;
 
       const reducer$ = childReducer$;
 


### PR DESCRIPTION
**Do not merge yet**

- [ ] There exists an issue discussing the need for this PR
- [x] I added new tests for the issue I fixed or built
- [x] I used `pnpm run commit` instead of `git commit`

This PR just shows *what kind of breaking changes* would happen if we would introduce TypeScript's `unknown` instead of `any`. The purpose is to avoid sneaking `any` types that tend to virally propagate, and instead to use `unknown` which forces the developer to cast the type of some sinks returned from an isolated component. In other words, `isolate` would never give `any` types, it would force the developer to think about what type they expect.

Open for discussion before I do the following:

- [x] rebase/split commits into one commit per package
- [x] release new isolate, breaking change, with migration guide
- [x] update each package to use the new isolate