### PR TITLE
Fix improper import statement

### DIFF
--- a/time/src/time-driver.ts
+++ b/time/src/time-driver.ts
@@ -8,8 +8,8 @@ import {makeAnimationFrames} from './animation-frames';
 import {makeThrottleAnimation} from './throttle-animation';
 import {runVirtually} from './run-virtually';
 import {TimeSource} from './time-source';
-import * as requestAnimationFrame from 'raf';
-import * as now from 'performance-now';
+import requestAnimationFrame from 'raf';
+import now from 'performance-now';
 
 function popAll(array: Array<any>): Array<any> {
   const poppedItems = [];


### PR DESCRIPTION
'raf' and 'performance-now' modules export functions, and 'import *' produces a namespace object, which is always a plain object. This error is hidden in cjs compile targets, because require() calls return with the exact module.exports instance. But in ES6 targets, compilers throw an error saying that 'requestAnimationFrame is not a function'

<!--
Thank you for your contribution!
To help speed up the process of merging your code, check the following:
-->

- [ ] There exists an issue discussing the need for this PR
- [ ] I added new tests for the issue I fixed or built
- [ ] I used `pnpm run commit` instead of `git commit`
