### PR TITLE
Convert rxjs-run deps to peerDeps

### DIFF
--- a/rxjs-run/package.json
+++ b/rxjs-run/package.json
@@ -29,13 +29,16 @@
   "module": "lib/es6/index.js",
   "typings": "lib/cjs/index.d.ts",
   "types": "lib/cjs/index.d.ts",
-  "dependencies": {
+  "peerDependencies": {
     "@cycle/run": "^5.2.0",
-    "rxjs": "~6.3.3",
+    "rxjs": "6.x",
     "symbol-observable": "^1.2.0",
     "xstream": "*"
   },
   "devDependencies": {
+    "@cycle/run": "^5.2.0",
+    "rxjs": "~6.3.3",
+    "symbol-observable": "^1.2.0",
     "@types/mocha": "5.2.x",
     "@types/node": "10.12.x",
     "@types/sinon": "5.0.x",


### PR DESCRIPTION
This fixes a bug described in https://github.com/cyclejs/cyclejs/issues/902

This issue likely affects other libs where `peerDependencies` were erroneously removed in favor of `dependencies`.  This is definitely a bug in the context of `rxjs-run`.

- [x ] There exists an issue discussing the need for this PR
- [ ] I added new tests for the issue I fixed or built
- [x ] I used `pnpm run commit` instead of `git commit`
