### PR TITLE
docs(META): clarify that you need to build before running tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,10 +7,11 @@ First of all, thank you for contributing. It’s appreciated.
 3. Use a Linux or Mac computer. Windows might work, but we cannot test that.
 4. Ensure pnpm is [installed](https://pnpm.js.org/docs/en/installation.html) (version `3.5.x` or higher).
 5. Run `pnpm install && pnpm recursive install` before anything else, and wait.
-6. Write code.
-7. Run `cd dom && pnpm test` (replace `dom` with the package you are testing) to lint and test. Don’t commit before fixing all errors and warnings.
-8. Commit using `pnpm run commit` and follow the CLI instructions.
-9. Make a pull request.
+6. RUN `npm recursive run build` to prebuild all cyclejs packages
+7. Write code.
+8. Run `cd dom && pnpm test` (replace `dom` with the package you are testing) to lint and test. Don’t commit before fixing all errors and warnings.
+9. Commit using `pnpm run commit` and follow the CLI instructions.
+10. Make a pull request.
 
 # To release new versions
 


### PR DESCRIPTION
ISSUES CLOSED: #908 

This is a very simple documentation update