### PR TITLE
chore(META): group browserstack sessions by build number

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -6,6 +6,15 @@ const ip = 'bs-local.com';
 
 const browserstack = require('./browserstack-karma.js');
 
+if (!process.env.TRAVIS_BUILD_NUMBER) {
+  const time = new Date()
+    .toISOString()
+    .replace(/T/, ' ')
+    .replace(/\..+/, '');
+
+  process.env.TRAVIS_BUILD_NUMBER = 'local(' + time + ')';
+}
+
 const browsers = ci
   ? Object.keys(browserstack)
   : live
@@ -33,6 +42,7 @@ module.exports = {
   },
   browserStack: {
     retryLimit: 3,
+    build: process.env.TRAVIS_BUILD_NUMBER,
   },
   browserNoActivityTimeout: 1000000,
   customLaunchers: browserstack,


### PR DESCRIPTION
Due to #901 the builds are not grouped any more in the browserstack ui. This should fix that

- [ ] There exists an issue discussing the need for this PR
- [ ] I added new tests for the issue I fixed or built
- [x] I used `pnpm run commit` instead of `git commit`
