### PR TITLE
Fix(dom): fix nonBubbling events only emit to one stream

### DIFF
--- a/dom/src/EventDelegator.ts
+++ b/dom/src/EventDelegator.ts
@@ -170,6 +170,8 @@ export class EventDelegator {
         dest = this.insertListener(subject, scopeChecker, eventType, options);
         input = [subject, eventType, finder, dest];
         nonBubbleSubject = subject;
+        this.nonBubblingListenersToAdd.add(input);
+        this.setupNonBubblingListener(input);
       } else {
         const [sub] = input;
         nonBubbleSubject = sub;
@@ -180,8 +182,6 @@ export class EventDelegator {
       let subscription: any = null;
       return xs.create({
         start: listener => {
-          self.nonBubblingListenersToAdd.add(input);
-          self.setupNonBubblingListener(input);
           subscription = nonBubbleSubject.subscribe(listener);
         },
         stop: () => {


### PR DESCRIPTION
Setup and add nonBubbling listeners before the stream starts.

I was reading the code for #940, there is an if statement that looks like it wants to differentiate between the first nonBubbleing listener and the rest, by looking for existing listeners in `this.nonBubblingListeners`. 

https://github.com/cyclejs/cyclejs/blob/2f4ebc9e7f466ca7af7cc1f642001b8887dccb36/dom/src/EventDelegator.ts#L168-L176

However that does not seems to work, because the listeners are added to `this.nonBubblingListeners` when the stream starts, which is too late.

https://github.com/cyclejs/cyclejs/blob/2f4ebc9e7f466ca7af7cc1f642001b8887dccb36/dom/src/EventDelegator.ts#L181-L186

I am trying to fix the problem by adding the listener earlier, it runs fine to me but I am not familiar with the internals, is this alright?

ISSUES CLOSED: #940

<!--
Thank you for your contribution!
To help speed up the process of merging your code, check the following:
-->

- [x] There exists an issue discussing the need for this PR
- [x] I added new tests for the issue I fixed or built
- [x] I used `pnpm run commit` instead of `git commit`
