### PR TITLE
feat: complete support for history.replace API

### DIFF
--- a/history/src/createHistory$.ts
+++ b/history/src/createHistory$.ts
@@ -28,7 +28,7 @@ function makeCallOnHistory(history: History) {
     }
 
     if (input.type === 'replace') {
-      history.replace(input.pathname, input.state);
+      history.replace({...input});
     }
 
     if (input.type === 'go') {

--- a/history/src/types.ts
+++ b/history/src/types.ts
@@ -23,7 +23,10 @@ export type PushHistoryInput = {
 export type ReplaceHistoryInput = {
   type: 'replace';
   pathname: Pathname;
+  search?: Search;
   state?: any;
+  hash?: Hash;
+  key?: LocationKey;
 };
 
 export type GoHistoryInput = {


### PR DESCRIPTION
Similarly to what #890 did for `history.push()`. The `history` library [supports](https://github.com/ReactTraining/history/blob/master/docs/Navigation.md) accepting a location-like object for both methods.

BREAKING CHANGE: :firecracker: The search/hash has to be provided as separate fields and can no longer be included in the pathname.