### PR TITLE
fix: 🐛 Make captureClicks compatible with history driver push

### DIFF
--- a/history/src/captureClicks.ts
+++ b/history/src/captureClicks.ts
@@ -30,7 +30,7 @@ function sameOrigin(href: string) {
   return href && href.indexOf(window.location.origin) === 0;
 }
 
-function makeClickListener(push: (p: string) => void) {
+function makeClickListener(push: (input: HistoryInput) => void) {
   return function clickListener(event: MouseEvent) {
     if (which(event) !== 1) {
       return;
@@ -76,11 +76,11 @@ function makeClickListener(push: (p: string) => void) {
 
     event.preventDefault();
     const {pathname, search, hash = ''} = element;
-    push(pathname + search + hash);
+    push({type: 'push', pathname, search, hash});
   };
 }
 
-function captureAnchorClicks(push: (p: string) => void) {
+function captureAnchorClicks(push: (input: HistoryInput) => void) {
   const listener = makeClickListener(push);
   if (typeof window !== 'undefined') {
     document.addEventListener(CLICK_EVENT, listener as EventListener, false);
@@ -96,8 +96,8 @@ export function captureClicks(historyDriver: HistoryDriver): HistoryDriver {
       start: () => {},
       stop: () => typeof cleanup === 'function' && cleanup(),
     });
-    cleanup = captureAnchorClicks((pathname: string) => {
-      internalSink$._n({type: 'push', pathname});
+    cleanup = captureAnchorClicks((input: HistoryInput) => {
+      internalSink$._n(input);
     });
     sink$._add(internalSink$);
     return historyDriver(internalSink$);

--- a/history/test/browser/common.ts
+++ b/history/test/browser/common.ts
@@ -84,6 +84,8 @@ describe('captureClicks', () => {
       .subscribe({
         next: (location: Location) => {
           assert.strictEqual(location.pathname, '/test');
+          assert.strictEqual(location.search, '?foo');
+          assert.strictEqual(location.hash, '#bar');
           sub.unsubscribe();
           sink.shamefullySendComplete();
           done();
@@ -93,7 +95,7 @@ describe('captureClicks', () => {
       });
 
     const a = document.createElement('a');
-    a.href = '/test';
+    a.href = '/test?foo#bar';
     document.body.appendChild(a);
 
     setTimeout(() => {


### PR DESCRIPTION
BREAKING CHANGE: 🧨 captureClicks will no longer combine the search/hash into the pathname.

✅ Closes: #909

<!--
Thank you for your contribution!
To help speed up the process of merging your code, check the following:
-->

- [x] There exists an issue discussing the need for this PR
- [x] I added new tests for the issue I fixed or built
- [x] I used `pnpm run commit` instead of `git commit`
