### PR TITLE
fix: add VNode typing to IsolateSink

### DIFF
--- a/dom/src/MainDOMSource.ts
+++ b/dom/src/MainDOMSource.ts
@@ -144,5 +144,5 @@ export class MainDOMSource {
   // not get bitten by a missing `this` reference.
 
   public isolateSource: (source: MainDOMSource, scope: string) => MainDOMSource;
-  public isolateSink: IsolateSink<any>;
+  public isolateSink: IsolateSink<VNode>;
 }

--- a/dom/test/browser/isolation.ts
+++ b/dom/test/browser/isolation.ts
@@ -346,7 +346,7 @@ describe('isolation', function() {
   it('should work with thunks', function(done) {
     function app(_sources: {DOM: MainDOMSource}) {
       const child$ = _sources.DOM.isolateSink(
-        xs.of(thunk('div.foo', () => div('.foo', [h4('.bar', 'Wrong')]), [])),
+        xs.of<VNode>(thunk('div.foo', () => div('.foo', [h4('.bar', 'Wrong')]), [])),
         'ISOLATION'
       );
 

--- a/dom/test/browser/isolation.ts
+++ b/dom/test/browser/isolation.ts
@@ -1079,7 +1079,7 @@ describe('isolation', function() {
         .take(2)
         .map(x => x + 1)
         .startWith(0)
-        .map(x => (x === 1 ? xs.of(div()) : (child.DOM as Stream<VNode>)))
+        .map(x => (x === 1 ? xs.of(div()) : (child.DOM)))
         .flatten();
       return {
         DOM: innerDOM$,


### PR DESCRIPTION
With `any` it prevents normal typing, with isolate.

<!--
Thank you for your contribution!
To help speed up the process of merging your code, check the following:
-->

- [ ] There exists an issue discussing the need for this PR
- [ ] I added new tests for the issue I fixed or built
- [ ] I used `pnpm run commit` instead of `git commit`
