### PR TITLE
[Cycle.js Neo] Allow to manually unwrap APIs

### DIFF
--- a/http/src/api.ts
+++ b/http/src/api.ts
@@ -6,7 +6,7 @@ import {
   filter,
   uponStart,
 } from '@cycle/callbags';
-import { IdGenerator } from '@cycle/run';
+import { IdGenerator, Api } from '@cycle/run';
 import { METHOD, ResponseType } from '@minireq/browser';
 
 import {
@@ -22,13 +22,13 @@ export function makeHttpApi(
   sinkSubject: Subject<SinkRequest>,
   gen: IdGenerator
 ): HttpApi {
-  return new HttpApi(sinkSubject, source, gen);
+  return new HttpApi(source, sinkSubject, gen);
 }
 
-export class HttpApi {
+export class HttpApi implements Api<ResponseStream> {
   constructor(
+    public readonly source: Producer<ResponseStream>,
     private sinkSubject: Subject<SinkRequest>,
-    private source: Producer<ResponseStream>,
     private gen: IdGenerator
   ) {}
 

--- a/run/src/index.ts
+++ b/run/src/index.ts
@@ -1,3 +1,3 @@
 export * from './types';
 
-export { run, makeMasterMain, setup, setupReusable } from './run';
+export { run, makeMasterMain, setup, setupReusable, applyApis } from './run';

--- a/run/src/types.ts
+++ b/run/src/types.ts
@@ -11,7 +11,11 @@ export type ApiFactory<Source, Sink> = (
   source: Producer<Source>,
   sinkSubject: Subject<Sink>,
   gen: IdGenerator
-) => any;
+) => Api<Source>;
+
+export interface Api<Source> {
+  readonly source: Producer<Source>;
+}
 
 export interface Driver<Source, Sink> {
   provideSource?(): Producer<Source>;

--- a/run/test/api.ts
+++ b/run/test/api.ts
@@ -1,0 +1,127 @@
+import * as assert from 'assert';
+import {
+  Producer,
+  Subject,
+  pipe,
+  map,
+  filter,
+  uponStart,
+  makeSubject,
+  subscribe,
+} from '@cycle/callbags';
+
+import {
+  run,
+  applyApis,
+  IdGenerator,
+  Subscription,
+  Driver,
+  Plugin,
+  Api,
+} from '../src/index';
+
+type RandomSource = { id: number; value: number };
+
+class RandomApi implements Api<RandomSource> {
+  constructor(
+    public readonly source: Producer<RandomSource>,
+    private sinkSubject: Subject<number>,
+    private gen: IdGenerator
+  ) {}
+
+  public get(): Producer<number> {
+    const id = this.gen();
+
+    return pipe(
+      this.source,
+      filter(x => x.id === id),
+      map(x => x.value),
+      uponStart(() => {
+        this.sinkSubject(1, id);
+      })
+    );
+  }
+}
+
+function randomApiFactory(
+  source: Producer<RandomSource>,
+  subject: Subject<number>,
+  gen: IdGenerator
+) {
+  return new RandomApi(source, subject, gen);
+}
+
+function makeRandomPlugin(n: number): Plugin<RandomSource, number> {
+  class RandomDriver implements Driver<RandomSource, number> {
+    private subject = makeSubject<RandomSource>();
+
+    provideSource() {
+      return this.subject;
+    }
+
+    consumeSink(sink: Producer<number>): Subscription {
+      return pipe(
+        sink,
+        subscribe(id => {
+          this.subject(1, { id, value: n });
+        })
+      );
+    }
+  }
+  return [new RandomDriver(), randomApiFactory];
+}
+
+describe('api', () => {
+  it('should automaticly apply apis when using run', () => {
+    const n = 5;
+    let called = false;
+
+    function main(sources: any) {
+      pipe(
+        sources.random.get(),
+        subscribe(x => {
+          assert.strictEqual(called, false);
+          assert.strictEqual(x, n);
+          called = true;
+        })
+      );
+      return {};
+    }
+
+    run(main, { random: makeRandomPlugin(n) }, []);
+  });
+
+  it('should allow to manually apply apis', () => {
+    const n = 99;
+    let called = false;
+
+    function child(sources: { random: RandomApi }): { log: Producer<number> } {
+      return {
+        log: sources.random.get(),
+      };
+    }
+
+    function parent(sources: { random: RandomApi }) {
+      const sinks1: any = child(sources);
+      assert.strictEqual(sinks1.random, undefined);
+
+      const sinks2 = applyApis(child, { random: randomApiFactory })(sources);
+      assert.strictEqual(typeof sinks2.random, 'function');
+
+      pipe(
+        sinks2.log,
+        subscribe(x => {
+          assert.strictEqual(called, false);
+          assert.strictEqual(x, n);
+          called = true;
+        })
+      );
+
+      return {
+        random: sinks2.random,
+      };
+    }
+
+    run(parent, { random: makeRandomPlugin(n) }, []);
+  });
+});


### PR DESCRIPTION
As discussed in the big neocycle PR, this adds the `applyApis` function to manually unwrap apis at any point in your application. The nice thing is, that this is simply the code from `makeMasterMain` factored out together with some new types and tests.