### PR TITLE
Fix cycle time diagrams

### DIFF
--- a/time/src/assert-equal.ts
+++ b/time/src/assert-equal.ts
@@ -228,7 +228,7 @@ function chunkBy(values: Array<any>, f: any) {
 
 function characterString(entry: any) {
   if (entry.type === 'next') {
-    return stringifyIfObject(entry.value);
+    return stringify(entry.value);
   }
 
   if (entry.type === 'complete') {
@@ -261,11 +261,9 @@ function diagramString(entries: Array<any>, interval: number): string {
     if (chunk.length === 1) {
       diagram[characterIndex] = characterString(chunk[0]);
     } else {
-      const characters = ['(', ...chunk.map(characterString), ')'];
-
-      characters.forEach((character, subIndex) => {
-        diagram[characterIndex + subIndex] = character;
-      });
+      diagram[characterIndex] = ['(', ...chunk.map(characterString), ')'].join(
+        ''
+      );
     }
   });
 
@@ -278,11 +276,12 @@ function strip(str: string): string {
   return lines.map(line => line.replace(/^\s{12}/, '')).join('\n');
 }
 
-function stringifyIfObject(value: any): string {
+function stringify(value: any): string {
   if (typeof value === 'object') {
     return JSON.stringify(value);
   }
-  return value;
+
+  return String(value);
 }
 
 function displayUnexpectedErrors(errors: Array<any>) {

--- a/time/src/diagram.ts
+++ b/time/src/diagram.ts
@@ -27,13 +27,18 @@ function makeDiagram(
     setMaxTime(diagramString.length * interval);
 
     let multipleValueFrame: false | number = false;
+    let index = -1;
 
-    characters.forEach((character, index) => {
+    characters.forEach(character => {
+      if (!multipleValueFrame) {
+        index++;
+      }
+
       if (character === '-') {
         return;
       }
 
-      let timeToSchedule = index * interval;
+      let timeToSchedule = currentTime() + index * interval;
 
       if (character === '(') {
         multipleValueFrame = timeToSchedule;


### PR DESCRIPTION
There was some issues related to time diagrams:
1. during the parsing of grouped values, the scheduled time index kept on incrementing for each character
2. during the creation of streams from diagram *after* the scheduler started, the scheduled timestamp were still starting at time `0`
3. during the printing of diff errors, merged values taking more than 1 character were colliding on the
diagram because of their length

It all resulted in strange diagrams being printed in test reports

BREAKING CHANGE:
The scheduling of events is now more correct, but people depending on the current behavior will be
impacted

ISSUES CLOSED: #962, #963

<!--
Thank you for your contribution!
To help speed up the process of merging your code, check the following:
-->

- [x] There exists an issue discussing the need for this PR : https://github.com/cyclejs/cyclejs/issues/963 and https://github.com/cyclejs/cyclejs/issues/964
- [x] I added new tests for the issue I fixed or built
- [x] I used `pnpm run commit` instead of `git commit`

(be indulgent for my english, it is not my first language)