### PR TITLE
cycle/state: Heterogenous Collections

### DIFF
--- a/docs/content/api/state.md
+++ b/docs/content/api/state.md
@@ -319,6 +319,32 @@ function Child(sources) {
 
 See the example code at `examples/advanced` for more details.
 
+### How to handle a heterogenous dynamic list
+
+Collections in the previous case only allowed a list of items using the same `Child` component. There are cases where you may need each item to be of a different component, depending on the item state.
+
+For those situations, use the `itemFactory` option instead of `item`. Its inputs are the same as for `itemKey`, and the output should be a Cycle.js component. See example below:
+
+```js
+const List = makeCollection({
+  itemFactory: (childState, index) => {
+    if (childState.type === 'a') return Apple
+    else if (childState.type === 'b') return Banana
+    else if (childState.type === 'c') return Cantaloupe
+    else return GenericFruit
+  }
+  itemKey: (childState, index) => String(index),
+  itemScope: key => key,
+  collectSinks: instances => {
+    return {
+      state: instances.pickMerge('state'),
+      DOM: instances.pickCombine('DOM')
+        .map(itemVNodes => ul(itemVNodes))
+    }
+  }
+});
+```
+
 ### How to share data among components, or compute derived data
 
 There are cases when you need more control over the way the state is passed from parent to child components. The standard mechanism of "peeling off" the state object is not flexible enough in situations such as:

--- a/state/src/types.ts
+++ b/state/src/types.ts
@@ -11,6 +11,10 @@ export type Lens<T, R> = {
 };
 export type ItemScopeFn = (key: string) => string | object;
 export type ItemKeyFn<S> = (state: S, index?: number) => string;
+export type ItemFactoryFn<S, So, Si> = (
+  state: S,
+  index?: number
+) => MainFn<So, Si>;
 export type Scope<T, R> = string | number | Lens<T, R>;
 export type InternalInstances<Si> = {
   dict: Map<string, Si>;


### PR DESCRIPTION
Currently, `makeCollection` is meant for a list of child items where each child is from the **same** component. Thus homogenous collections. This PR allows `makeCollection` to have heterogenous child items, i.e., **different** components for the children.

## Context

I'm adapting Manyverse to run in Electron, and I'm having to build an alternative to [cycle-native-navigation](https://github.com/staltz/cycle-native-navigation), so I'm working with navigation logic. The basic architecture of my navigation solution is that there is a map of strings to components, such as

```js
const screenMap = {
  "MainScreen": main,
  "ProfileScreen": profile,
  "SettingsScreen": settings,
}
```

And then there is the "stack" of screens, which is just an array that gets pushed when a new screen is opened, and gets popped when that screen gets "back" navigation. The last item in the array is the "current screen". For that, I'm using `@cycle/state` and the shape of the state is (very simplified here:) `Array<ScreenName>` where `type ScreenName = "MainScreen" | "ProfileScreen" | "SettingsScreen"`. To handle this array, I'm using `makeCollection` because a new instance has be created when the stack grows, etc.

## Problem

`makeCollection` expects the `item` option to be a Cycle.js component, but this is a static component, and in my case I need it to *depend* on the item state. It's quite a brain twist to do this with the current `makeCollection` API, for instance this is what I was trying to do:

```js
const screenMap = {
  "MainScreen": main,
  "ProfileScreen": profile,
  "SettingsScreen": settings,
}

function Child(sources) {
  const state$ = sources.state.stream;
  
  const sinks$ = state$.map(screenName => {
    const component = screenMap[screenName];
    if (!component) {
      throw new Error('no component for ', screenName);
    }
    const sinks = component(sources);
    return sinks;
  });
  
  return // ??? WHAT DO WE DO HERE ???
  // Assume that we cannot hard-code the sink channels because
  // the solution should be generic enough so that it can become a
  // library, and thus we don't know which drivers the app developer
  // is using
}
    
const List = makeCollection({
  item: Child,
  itemKey: (childState, index) => childState,
  itemScope: (key) => key,
  collectSinks: (instances) => ({
     // etc
  }),
});
```

## Solution

I considered a couple different options, but this PR contains the simplest and cleanest solution in my opinion.

First, a theorem: _Upon child instantiation, the child state is always known synchronously._ Proof left for the reader. :smile: A corollary is that we don't need stream primitives to wrap the initial child state.

This PR adds `itemFactory` as another option. `makeCollection` will use either `itemFactory` or `item`, they are mutually exclusive. The type is `(childState, index) => childComponent`. This makes it much easier for me to implement the navigation logic like this:

```js
const screenMap = {
  "MainScreen": main,
  "ProfileScreen": profile,
  "SettingsScreen": settings,
}

const List = makeCollection({
  itemFactory: (screenName, index) => {
    const component = screenMap[screenName];
    if (!component) {
      throw new Error('no component for ', screenName);
    }
    return component;
  },
  itemKey: (childState, index) => childState,
  itemScope: (key) => key,
  collectSinks: (instances) => ({
     // etc
  }),
});
```

Apart from the new types, the implementation is very simple, and should be a no-brainer to add to neocycle.