### PR TITLE
[time] Fix ModuleNotFoundError for RxJS and Most.js

### DIFF
--- a/time/README.md
+++ b/time/README.md
@@ -92,13 +92,13 @@ import {timeDriver} from '@cycle/time';
 RxJS:
 <!-- skip-example -->
 ```js
-import {timeDriver} from '@cycle/time/rxjs';
+import {timeDriver} from '@cycle/time/lib/es6/rxjs';
 ```
 
 most.js:
 <!-- skip-example -->
 ```js
-import {timeDriver} from '@cycle/time/most';
+import {timeDriver} from '@cycle/time/lib/es6/most';
 ```
 
 Then it needs to be added to the drivers object.
@@ -176,13 +176,13 @@ import {mockTimeSource} from '@cycle/time';
 RxJS:
 <!-- skip-example -->
 ```js
-import {mockTimeSource} from '@cycle/time/rxjs';
+import {mockTimeSource} from '@cycle/time/lib/es6/rxjs';
 ```
 
 most.js:
 <!-- skip-example -->
 ```js
-import {mockTimeSource} from '@cycle/time/most';
+import {mockTimeSource} from '@cycle/time/lib/es6/most';
 ```
 
 For testing components that use `@cycle/dom` we will also want `mockDOMSource` and potentially `snabbdom-selector`.

--- a/time/package.json
+++ b/time/package.json
@@ -48,11 +48,7 @@
   },
   "files": [
     "lib/",
-    "dist/",
-    "most.js",
-    "rxjs.js",
-    "most.d.ts",
-    "rxjs.d.ts"
+    "dist/"
   ],
   "react-native": {
     "variable-diff": false
@@ -70,7 +66,6 @@
     "test": "pnpm run test-node && pnpm run test-docs",
     "test-ci": "../.scripts/retry.sh pnpm test",
     "test-docs": "markdown-doctest",
-    "postbuild": "tsc rxjs.ts most.ts --declaration --lib DOM,ES5,ES6 && rm src/*.d.ts && rm src/*.js",
     "prepublishOnly": "pnpm run build && pnpm test"
   }
 }

--- a/time/src/index.ts
+++ b/time/src/index.ts
@@ -1,6 +1,6 @@
-import {timeDriver as timeDriverUntyped} from './src/time-driver';
-import {mockTimeSource as mockTimeSourceUntyped} from './src/mock-time-source';
-import {TimeSource, MockTimeSource, Operator} from './src/time-source';
+import {timeDriver as timeDriverUntyped} from './time-driver';
+import {mockTimeSource as mockTimeSourceUntyped} from './mock-time-source';
+import {TimeSource, MockTimeSource, Operator} from './time-source';
 
 function mockTimeSource(args?: Object): MockTimeSource {
   return mockTimeSourceUntyped(args);

--- a/time/src/most.ts
+++ b/time/src/most.ts
@@ -2,10 +2,10 @@ import * as most from 'most';
 import {Stream} from 'most';
 import {setAdapt} from '@cycle/run/lib/adapt';
 
-import {mockTimeSource as mockTimeSourceUntyped} from './src/mock-time-source';
-import {timeDriver as timeDriverUntyped} from './src/time-driver';
-import {Frame} from './lib/cjs/src/animation-frames';
-import {Comparator, OperatorArgs} from './src/types';
+import {mockTimeSource as mockTimeSourceUntyped} from './mock-time-source';
+import {timeDriver as timeDriverUntyped} from './time-driver';
+import {Frame} from './animation-frames';
+import {Comparator, OperatorArgs} from './types';
 
 setAdapt(stream => most.from(stream as any));
 

--- a/time/src/rxjs.ts
+++ b/time/src/rxjs.ts
@@ -2,10 +2,10 @@ import {Observable, from} from 'rxjs';
 // tslint:disable-next-line:no-import-side-effect
 import {setAdapt} from '@cycle/run/lib/adapt';
 
-import {mockTimeSource as mockTimeSourceUntyped} from './src/mock-time-source';
-import {timeDriver as timeDriverUntyped} from './src/time-driver';
-import {Frame} from './lib/cjs/src/animation-frames';
-import {Comparator, OperatorArgs} from './src/types';
+import {mockTimeSource as mockTimeSourceUntyped} from './mock-time-source';
+import {timeDriver as timeDriverUntyped} from './time-driver';
+import {Frame} from './animation-frames';
+import {Comparator, OperatorArgs} from './types';
 
 setAdapt(from as any);
 

--- a/time/test/jasmine-support.ts
+++ b/time/test/jasmine-support.ts
@@ -1,4 +1,4 @@
-import {mockTimeSource} from '../';
+import {mockTimeSource} from '../src/index';
 import {setAdapt} from '@cycle/run/lib/adapt';
 
 describe('jasmine support', () => {

--- a/time/test/most.ts
+++ b/time/test/most.ts
@@ -1,7 +1,7 @@
 import * as most from 'most';
 import {setAdapt} from '@cycle/run/lib/adapt';
 
-import {mockTimeSource} from '../most';
+import {mockTimeSource} from '../src/most';
 
 describe('most', () => {
   before(() => setAdapt(stream => most.from(stream as any)));

--- a/time/test/rxjs.ts
+++ b/time/test/rxjs.ts
@@ -1,7 +1,7 @@
 import {Observable, from, of} from 'rxjs';
 import {setAdapt} from '@cycle/run/lib/adapt';
 
-import {mockTimeSource} from '../rxjs';
+import {mockTimeSource} from '../src/rxjs';
 
 describe('rxjs', () => {
   before(() => setAdapt(from as any));

--- a/time/test/time-driver.ts
+++ b/time/test/time-driver.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import {timeDriver, TimeSource, Operator} from '../';
+import {timeDriver, TimeSource, Operator} from '../src/index';
 import xs, {Stream} from 'xstream';
 import {setAdapt} from '@cycle/run/lib/adapt';
 

--- a/time/test/time.ts
+++ b/time/test/time.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import {mockTimeSource, timeDriver, TimeSource, Operator} from '../index';
+import {mockTimeSource, timeDriver, TimeSource, Operator} from '../src/index';
 import {mockDOMSource} from '@cycle/dom';
 import xs, {Stream} from 'xstream';
 import {setAdapt, adapt} from '@cycle/run/lib/adapt';

--- a/time/test/xstream.ts
+++ b/time/test/xstream.ts
@@ -1,4 +1,4 @@
-import {mockTimeSource} from '../';
+import {mockTimeSource} from '../src/index';
 import {setAdapt} from '@cycle/run/lib/adapt';
 import xs from 'xstream';
 

--- a/time/tsconfig.json
+++ b/time/tsconfig.json
@@ -11,7 +11,9 @@
     ]
   },
   "files": [
-    "index.ts",
+    "src/index.ts",
+    "src/rxjs.ts",
+    "src/most.ts",
     "custom-typings.d.ts"
   ]
 }

--- a/time/tsconfig.lint.json
+++ b/time/tsconfig.lint.json
@@ -1,7 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "files": [
-    "index.ts",
+    "src/index.ts",
+    "src/most.ts",
+    "src/rxjs.ts",
     "custom-typings.d.ts",
     "test/jasmine-support.ts",
     "test/most.ts",


### PR DESCRIPTION
Normalize the way of importing `rxjs` and `most` variants from `@cycle/time` as in `@cycle/dom` and `@cycle/http`.

**Breaking change**

 If you are using RxJS change
`import {timeDriver} from '@cycle/time/rxjs'` to
`import {timeDriver} from '@cycle/time/lib/es6/rxjs'`.

If you are using Most.js change
`import {timeDriver} from '@cycle/time/most'` to
`import {timeDriver} from '@cycle/time/lib/es6/most'`.

Closes: #977

<!--
Thank you for your contribution!
To help speed up the process of merging your code, check the following:
-->

- [x] There exists an issue discussing the need for this PR
- [ ] I added new tests for the issue I fixed or built
- [x] I used `pnpm run commit` instead of `git commit`
