### PR TITLE
docs: add README files for examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -20,3 +20,28 @@ Start with the examples under the basic folder in this order:
 
 This will get you introduced to one main concept with each example. Make sure
 to reach for each example's README file for more context.
+
+After that, continue with the examples under the intermediate folder:
+
+1. hello-lastname
+2. bmi-typescript
+3. animation
+4. http-search-github
+5. tsx-seconds-elapsed
+
+These examples introduce typed sources and sinks, component composition,
+animation streams, categorized HTTP responses, and TSX rendering.
+
+Then move on to the advanced folder:
+
+1. animated-letters
+2. autocomplete-search
+3. bmi-nested
+4. custom-driver
+5. isomorphic
+6. many
+7. nested-folders
+8. routing-view
+
+These examples show recursive components, dynamic collections, custom drivers,
+isomorphic rendering, routing, and more involved stream orchestration.

--- a/examples/advanced/animated-letters/README.md
+++ b/examples/advanced/animated-letters/README.md
@@ -1,0 +1,23 @@
+# Cycle.js Animated Letters example
+
+This example lets you press letter keys to add and remove animated letters.
+
+This is good for:
+
+- Reading non-DOM events through a custom source
+- Comparing consecutive states with `pairwise`
+- Expanding state changes into animation frames with the Time driver
+
+## How it works
+
+Keyboard events are converted into single-letter actions. The model keeps a
+sorted list of active letters, and the animation layer compares the previous
+and next letter lists to find added and removed letters. Each change is expanded
+into short timed frame streams, then folded into animated letter sizes for
+rendering.
+
+## Usage
+
+1. Type `npm start`
+2. Open the `index.html` in your browser, with the full path,
+   e.g. `file:///Users/myself/cyclejs/examples/advanced/animated-letters/index.html`

--- a/examples/advanced/autocomplete-search/README.md
+++ b/examples/advanced/autocomplete-search/README.md
@@ -2,6 +2,22 @@
 
 Equivalent to a ClojureScript example by @swannodette: http://swannodette.github.io/2013/08/17/comparative/
 
+This example searches a local list of suggestions as the user types.
+
+This is good for:
+
+- Combining keyboard input with derived suggestion state
+- Managing focused suggestions separately from the query text
+- Running the app with hot reloading while preserving state
+
+## How it works
+
+The app keeps the search query, suggestion matches, and selected suggestion in
+streams. DOM input events update the query, keyboard events move the selection,
+and the view renders both the input field and the filtered suggestion list.
+
+## Usage
+
 Run `npm run live` to use this app with hot reloading enabled: change the source
 code and save the file to see near instant updates to the app, without resetting
 the app's state.

--- a/examples/advanced/bmi-nested/README.md
+++ b/examples/advanced/bmi-nested/README.md
@@ -1,0 +1,22 @@
+# Cycle.js BMI nested example
+
+This example builds the BMI calculator from nested JavaScript components.
+
+This is good for:
+
+- Comparing JavaScript component composition with the TypeScript BMI example
+- Passing props streams into reusable child components
+- Combining child sink streams in a parent component
+
+## How it works
+
+The root app delegates to `BmiCalculator`, which creates two reusable slider
+components. Each slider emits a DOM stream and a value stream. The parent
+combines the weight and height values to calculate BMI, then combines that BMI
+with the slider DOM streams to render the complete UI.
+
+## Usage
+
+1. Type `npm start`
+2. Open the `index.html` in your browser, with the full path,
+   e.g. `file:///Users/myself/cyclejs/examples/advanced/bmi-nested/index.html`

--- a/examples/advanced/custom-driver/README.md
+++ b/examples/advanced/custom-driver/README.md
@@ -1,0 +1,24 @@
+# Cycle.js Custom Driver example
+
+This example counts clicks over time and renders the result through a chart
+driver.
+
+This is good for:
+
+- Writing an app that outputs to a sink other than DOM
+- Separating intent, model, and view streams
+- Understanding how a custom driver can bridge Cycle.js streams to another UI
+  library
+
+## How it works
+
+DOM clicks are merged with periodic Time driver ticks. The model folds these
+events into a history of click counts per second. The view maps that history
+into chart data, and the custom Chart driver renders the data into the chart
+container.
+
+## Usage
+
+1. Type `npm start`
+2. Open the `index.html` in your browser, with the full path,
+   e.g. `file:///Users/myself/cyclejs/examples/advanced/custom-driver/index.html`

--- a/examples/advanced/isomorphic/README.md
+++ b/examples/advanced/isomorphic/README.md
@@ -1,0 +1,21 @@
+# Cycle.js Isomorphic example
+
+This example renders the same Cycle.js app on the server and in the browser.
+
+This is good for:
+
+- Seeing how one app function can support server and client rendering
+- Using a PreventDefault sink to keep link navigation inside the app
+- Passing route context into an app during initial render
+
+## How it works
+
+The shared `app.js` file renders a small two-page app from a route context.
+On the server, the route comes from the incoming request. On the client, link
+clicks are converted into new route context values and `history.pushState()`
+updates the URL. The same view code handles both environments.
+
+## Usage
+
+1. Type `npm start`
+2. Open the local URL printed by the server

--- a/examples/advanced/many/README.md
+++ b/examples/advanced/many/README.md
@@ -1,0 +1,23 @@
+# Cycle.js Many example
+
+This example creates, edits, and removes many isolated item components.
+
+This is good for:
+
+- Managing dynamic collections of child components
+- Using `isolate()` so repeated components do not share DOM scopes
+- Combining child DOM streams and child remove streams
+
+## How it works
+
+The list component turns add and remove events into reducer functions over an
+array of item records. New records create isolated item components with random
+color and width props. Each child exposes a DOM stream and a remove stream; the
+parent combines child DOM streams for rendering and merges child remove streams
+back into list actions.
+
+## Usage
+
+1. Type `npm start`
+2. Open the `index.html` in your browser, with the full path,
+   e.g. `file:///Users/myself/cyclejs/examples/advanced/many/index.html`

--- a/examples/advanced/nested-folders/README.md
+++ b/examples/advanced/nested-folders/README.md
@@ -1,0 +1,22 @@
+# Cycle.js Nested Folders example
+
+This example renders folders that can add and remove nested child folders.
+
+This is good for:
+
+- Using `cycle-onionify` for nested state
+- Managing recursive component collections
+- Combining parent reducers with child reducers
+
+## How it works
+
+`Folder` models its own add/remove actions as reducer streams. Child folders are
+managed through `makeCollection()`, keyed by each child folder id and scoped to
+the `children` state branch. The parent combines its own reducer stream with
+the child onion reducer stream, while combining child DOM streams for rendering.
+
+## Usage
+
+1. Type `npm start`
+2. Open the `index.html` in your browser, with the full path,
+   e.g. `file:///Users/myself/cyclejs/examples/advanced/nested-folders/index.html`

--- a/examples/advanced/routing-view/README.md
+++ b/examples/advanced/routing-view/README.md
@@ -1,0 +1,21 @@
+# Cycle.js Routing View example
+
+This example renders different page views from hash history state.
+
+This is good for:
+
+- Using the History driver as both a source and a sink
+- Mapping navigation clicks into route changes
+- Rendering views from the current history object
+
+## How it works
+
+Navigation clicks are mapped to page names and sent to the History driver. The
+app reads the current history source, chooses a page view from the pathname, and
+renders both the navigation menu and a JSON representation of the history object.
+
+## Usage
+
+1. Type `npm start`
+2. Open the `index.html` in your browser, with the full path,
+   e.g. `file:///Users/myself/cyclejs/examples/advanced/routing-view/index.html`

--- a/examples/basic/bmi-naive/README.md
+++ b/examples/basic/bmi-naive/README.md
@@ -1,0 +1,24 @@
+# Cycle.js BMI naive example
+
+This example calculates BMI from two range sliders: weight and height.
+
+This is good for:
+
+- Combining independent input streams into one state stream
+- Deriving calculated values from UI state
+- Seeing the BMI app written inline before it is split into components in
+  later examples
+
+## How it works
+
+The app listens to input events from the weight and height sliders. Each stream
+starts with a default value, and `Observable.combineLatest()` combines the
+latest weight and height into a state object containing `weight`, `height`, and
+`bmi`. That state is mapped to a virtual DOM tree with two sliders and the
+calculated BMI.
+
+## Usage
+
+1. Type `npm start`
+2. Open the `index.html` in your browser, with the full path,
+   e.g. `file:///Users/myself/cyclejs/examples/basic/bmi-naive/index.html`

--- a/examples/basic/checkbox/README.md
+++ b/examples/basic/checkbox/README.md
@@ -1,0 +1,22 @@
+# Cycle.js Checkbox example
+
+This example renders a checkbox and displays whether it is on or off.
+
+This is good for:
+
+- Reading DOM events with `sources.DOM.select(...).events(...)`
+- Turning browser event objects into application state
+- Using `startWith()` to provide an initial UI state before the first event
+
+## How it works
+
+The program listens to `change` events from the checkbox input, maps each event
+to `event.target.checked`, and starts the stream with `false`. Each boolean
+value is then mapped to a virtual DOM tree that contains the checkbox and the
+current text state.
+
+## Usage
+
+1. Type `npm start`
+2. Open the `index.html` in your browser, with the full path,
+   e.g. `file:///Users/myself/cyclejs/examples/basic/checkbox/index.html`

--- a/examples/basic/counter/README.md
+++ b/examples/basic/counter/README.md
@@ -1,0 +1,22 @@
+# Cycle.js Counter example
+
+This example renders increment and decrement buttons and keeps a running count.
+
+This is good for:
+
+- Combining multiple DOM event streams with `xs.merge()`
+- Representing user intent as small action values
+- Accumulating state over time with `fold()`
+
+## How it works
+
+Clicking the decrement button emits `-1`, and clicking the increment button
+emits `+1`. These action streams are merged and folded into a count stream.
+The count stream is mapped to a virtual DOM tree that displays both buttons
+and the current count.
+
+## Usage
+
+1. Type `npm start`
+2. Open the `index.html` in your browser, with the full path,
+   e.g. `file:///Users/myself/cyclejs/examples/basic/counter/index.html`

--- a/examples/basic/http-random-user/README.md
+++ b/examples/basic/http-random-user/README.md
@@ -1,0 +1,22 @@
+# Cycle.js HTTP random user example
+
+This example fetches and displays a random user from JSONPlaceholder.
+
+This is good for:
+
+- Sending HTTP requests from a Cycle.js app
+- Categorizing requests so the matching responses can be selected
+- Adding basic TypeScript types to DOM and HTTP sources
+
+## How it works
+
+Clicking the button creates a GET request object with the `users` category.
+The HTTP driver receives that request and returns response streams. The app
+selects the `users` responses, flattens the response stream, reads the response
+body, and renders the user's name, email, and website.
+
+## Usage
+
+1. Type `npm start`
+2. Open the `index.html` in your browser, with the full path,
+   e.g. `file:///Users/myself/cyclejs/examples/basic/http-random-user/index.html`

--- a/examples/basic/jsx-seconds-elapsed/README.md
+++ b/examples/basic/jsx-seconds-elapsed/README.md
@@ -1,0 +1,21 @@
+# Cycle.js JSX seconds elapsed example
+
+This example displays how many seconds have elapsed since the app started.
+
+This is good for:
+
+- Using the Time driver to produce periodic events
+- Rendering Cycle.js virtual DOM with JSX
+- Seeing the JavaScript version of the TSX seconds elapsed example
+
+## How it works
+
+The Time driver emits a value once per second. The stream is incremented from
+zero, starts immediately with `0`, and is mapped to JSX that displays the
+elapsed seconds.
+
+## Usage
+
+1. Type `npm start`
+2. Open the `index.html` in your browser, with the full path,
+   e.g. `file:///Users/myself/cyclejs/examples/basic/jsx-seconds-elapsed/index.html`

--- a/examples/intermediate/animation/README.md
+++ b/examples/intermediate/animation/README.md
@@ -1,0 +1,23 @@
+# Cycle.js Animation example
+
+This example animates a square through a sequence of movements after a button
+click.
+
+This is good for:
+
+- Starting animation streams from DOM events
+- Sequencing streams with `xstream/extra/concat`
+- Using `xstream/extra/tween` to produce animated values
+
+## How it works
+
+Clicking the button starts a stream made from three tweened movement phases:
+left-to-right, top-to-bottom, and a circular return. The phases are concatenated
+so they run in order. Each emitted coordinate is mapped to inline styles for the
+target square.
+
+## Usage
+
+1. Type `npm start`
+2. Open the `index.html` in your browser, with the full path,
+   e.g. `file:///Users/myself/cyclejs/examples/intermediate/animation/index.html`

--- a/examples/intermediate/bmi-typescript/README.md
+++ b/examples/intermediate/bmi-typescript/README.md
@@ -1,0 +1,22 @@
+# Cycle.js BMI TypeScript example
+
+This example rewrites the BMI calculator with typed, reusable components.
+
+This is good for:
+
+- Splitting a Cycle.js app into smaller components
+- Isolating component DOM scopes with `@cycle/isolate`
+- Typing component sources, sinks, and props streams in TypeScript
+
+## How it works
+
+`BmiCalculator` creates two isolated `LabeledSlider` components: one for weight
+and one for height. Each slider receives a props stream and returns both a DOM
+stream and a `value$` stream. The calculator combines the two value streams,
+calculates BMI, and renders the two sliders with the result.
+
+## Usage
+
+1. Type `npm start`
+2. Open the `index.html` in your browser, with the full path,
+   e.g. `file:///Users/myself/cyclejs/examples/intermediate/bmi-typescript/index.html`

--- a/examples/intermediate/hello-lastname/README.md
+++ b/examples/intermediate/hello-lastname/README.md
@@ -1,0 +1,22 @@
+# Cycle.js Hello Lastname example
+
+This example combines first-name and last-name inputs into a formatted greeting.
+
+This is good for:
+
+- Combining streams with `xs.combine()`
+- Splitting valid and invalid state into separate streams
+- Using TypeScript interfaces for Cycle.js sources and sinks
+
+## How it works
+
+The app reads first-name and last-name input events from the DOM. The last name
+is uppercased, and both streams are combined into one remembered name stream.
+Valid names are formatted as `LAST, First`; invalid names produce an empty
+greeting. The merged output stream is rendered as a form and heading.
+
+## Usage
+
+1. Type `npm start`
+2. Open the `index.html` in your browser, with the full path,
+   e.g. `file:///Users/myself/cyclejs/examples/intermediate/hello-lastname/index.html`

--- a/examples/intermediate/http-search-github/README.md
+++ b/examples/intermediate/http-search-github/README.md
@@ -1,0 +1,23 @@
+# Cycle.js HTTP search GitHub example
+
+This example searches GitHub repositories from a text input.
+
+This is good for:
+
+- Debouncing DOM input before making HTTP requests
+- Filtering HTTP responses by request category
+- Ignoring unrelated HTTP responses in the same app
+
+## How it works
+
+Input events from the search field are debounced through the Time driver. Each
+non-empty query becomes a categorized GitHub API request. The app also emits a
+separate Google request stream to demonstrate why response categories matter.
+Only `github` responses are selected, flattened, and rendered as a list of
+repository links.
+
+## Usage
+
+1. Type `npm start`
+2. Open the `index.html` in your browser, with the full path,
+   e.g. `file:///Users/myself/cyclejs/examples/intermediate/http-search-github/index.html`

--- a/examples/intermediate/tsx-seconds-elapsed/README.md
+++ b/examples/intermediate/tsx-seconds-elapsed/README.md
@@ -1,0 +1,22 @@
+# Cycle.js TSX seconds elapsed example
+
+This example displays elapsed seconds using TypeScript and TSX.
+
+This is good for:
+
+- Typing Cycle.js sources and sinks
+- Using the Time driver with TypeScript
+- Rendering virtual DOM with TSX
+
+## How it works
+
+The Time driver emits once per second. The stream is incremented from zero,
+starts immediately with `0`, and is mapped to TSX that displays the elapsed
+seconds. The source and sink types describe the DOM and Time driver inputs and
+the DOM stream output.
+
+## Usage
+
+1. Type `npm start`
+2. Open the `index.html` in your browser, with the full path,
+   e.g. `file:///Users/myself/cyclejs/examples/intermediate/tsx-seconds-elapsed/index.html`


### PR DESCRIPTION
## Summary
- add README files for every example directory that did not have one
- document what each example demonstrates and how the stream flow works
- extend the top-level examples study guide with intermediate and advanced paths

## Verification
- `git diff --cached --check` before commit
- Confirmed every example directory with `package.json` now has a `README.md`

This is documentation-only, so I did not run the monorepo package test suite.

Fixes #480
