### PR TITLE
Add mock HTTP driver helper

### DIFF
--- a/http/package.json
+++ b/http/package.json
@@ -31,6 +31,7 @@
     "most": "^1.7.3",
     "rxjs": "^6.3.3",
     "superagent": "^3.8.3",
+    "superagent-mock": "^3.7.0",
     "xstream": "*"
   },
   "devDependencies": {

--- a/http/src/http-driver.ts
+++ b/http/src/http-driver.ts
@@ -151,7 +151,9 @@ function normalizeRequestInput(reqInput: RequestInput): RequestOptions {
 
 export type ResponseMemoryStream = MemoryStream<Response> & ResponseStream;
 
-function requestInputToResponse$(reqInput: RequestInput): ResponseMemoryStream {
+export function requestInputToResponse$(
+  reqInput: RequestInput
+): ResponseMemoryStream {
   let response$ = createResponse$(reqInput).remember();
   const reqOptions = softNormalizeRequestInput(reqInput);
   if (!reqOptions.lazy) {

--- a/http/src/index.ts
+++ b/http/src/index.ts
@@ -59,6 +59,15 @@
  * @function makeHTTPDriver
  */
 export {makeHTTPDriver} from './http-driver';
+/**
+ * A factory function to create mocked HTTP drivers for testing purposes.
+ *
+ * Takes an array of superagent-mock configuration objects as argument, and
+ * returns an HTTP driver that can be given to Cycle.js apps in tests.
+ *
+ * @function mockHTTPDriver
+ */
+export {mockHTTPDriver, MockConfig} from './mockHTTPDriver';
 export {
   RequestOptions,
   Attachment,

--- a/http/src/mockHTTPDriver.ts
+++ b/http/src/mockHTTPDriver.ts
@@ -1,0 +1,44 @@
+import {Stream} from 'xstream';
+import {Driver} from '@cycle/run';
+import {requestInputToResponse$} from './http-driver';
+import {MainHTTPSource} from './MainHTTPSource';
+import * as superagent from 'superagent';
+import * as mockSuperagent from 'superagent-mock';
+import {HTTPSource, RequestInput} from './interfaces';
+
+export type MockConfig = mockSuperagent.MockConfig;
+
+const forbidRealRequestsConfig: MockConfig = {
+  pattern: '.*',
+  fixtures: () => {
+    throw new Error(
+      'You did not provide a sufficient config to catch all requests'
+    );
+  },
+};
+
+export function mockHTTPDriver(
+  config: Array<MockConfig>,
+  logger?: Function
+): Driver<Stream<RequestInput>, HTTPSource> {
+  function fakedHTTPDriver(
+    request$: Stream<RequestInput>,
+    name: string = 'HTTP'
+  ): HTTPSource {
+    const {unset} = mockSuperagent(
+      superagent,
+      [...config, forbidRealRequestsConfig],
+      logger
+    );
+    const response$$ = request$.map(requestInputToResponse$);
+    const httpSource = new MainHTTPSource(response$$, name, []);
+    response$$.addListener({
+      next: () => {},
+      error: () => {},
+      complete: unset,
+    });
+    return httpSource;
+  }
+
+  return fakedHTTPDriver;
+}

--- a/http/test/node.ts
+++ b/http/test/node.ts
@@ -2,7 +2,10 @@ import 'symbol-observable'; //tslint:disable-line
 import * as assert from 'assert';
 import {Observable, of} from 'rxjs';
 import {mergeAll} from 'rxjs/operators';
+import xs from 'xstream';
 import {setup} from '@cycle/rxjs-run';
+import {setup as setupXStream} from '@cycle/run';
+import {mockHTTPDriver} from '../src/index';
 import {HTTPSource, makeHTTPDriver} from '../src/rxjs';
 import {runTests} from './browser/common';
 import {globalSandbox} from './support/global';
@@ -170,5 +173,93 @@ describe('HTTP Driver in Node.js', function() {
       });
 
     run();
+  });
+});
+
+describe('mockHTTPDriver', function() {
+  let dispose: Function | null = null;
+
+  afterEach(function() {
+    if (dispose) {
+      dispose();
+      dispose = null;
+    }
+  });
+
+  it('mocks requests', function(done) {
+    function main() {
+      return {
+        HTTP: xs.of('http://foo.bar'),
+      };
+    }
+
+    const drivers = {
+      HTTP: mockHTTPDriver([
+        {
+          pattern: 'http://foo.bar',
+          fixtures: () => ({body: 'hi', status: 200}),
+          callback: (_match: any, data: any) => data,
+        },
+      ]),
+    };
+
+    const {sources, run} = setupXStream(main, drivers);
+
+    sources.HTTP.select().subscribe({
+      next(response$) {
+        assert.strictEqual(response$.request.url, 'http://foo.bar');
+        response$.subscribe({
+          next: res => {
+            assert.strictEqual(res.status, 200);
+            assert.strictEqual(res.body, 'hi');
+            done();
+          },
+          error: done,
+        });
+      },
+      error: done,
+    });
+
+    dispose = run();
+  });
+
+  it('throws instead of making real requests when the config misses', function(done) {
+    function main() {
+      return {
+        HTTP: xs.of('http://foo.bar'),
+      };
+    }
+
+    const drivers = {
+      HTTP: mockHTTPDriver([
+        {
+          pattern: 'http://foo.babar',
+          fixtures: () => {},
+        },
+      ]),
+    };
+
+    const {sources, run} = setupXStream(main, drivers);
+
+    sources.HTTP.select().subscribe({
+      next: response$ => {
+        assert.strictEqual(response$.request.url, 'http://foo.bar');
+        response$.subscribe({
+          next: () => {
+            done(new Error('should not make a real request'));
+          },
+          error: err => {
+            assert.strictEqual(
+              err.message,
+              'You did not provide a sufficient config to catch all requests'
+            );
+            done();
+          },
+        });
+      },
+      error: done,
+    });
+
+    dispose = run();
   });
 });

--- a/http/tsconfig.json
+++ b/http/tsconfig.json
@@ -8,11 +8,16 @@
       "es2015.collection",
       "es2015.promise",
       "es2015.iterable"
+    ],
+    "typeRoots": [
+      "./node_modules/@types",
+      "./typings"
     ]
   },
   "files": [
     "src/index.ts",
     "src/rxjs.ts",
-    "src/most.ts"
+    "src/most.ts",
+    "src/mockHTTPDriver.ts"
   ]
 }

--- a/http/typings/superagent-mock/index.d.ts
+++ b/http/typings/superagent-mock/index.d.ts
@@ -1,0 +1,36 @@
+declare module 'superagent-mock' {
+  import {SuperAgentStatic} from 'superagent';
+
+  type methodHandler = (match: RegExpExecArray, fixtures: any) => any;
+
+  namespace mockSuperagent {
+    export type MockConfig = {
+      pattern: string;
+      fixtures(
+        match: RegExpExecArray,
+        data: any,
+        headers: any,
+        context: any
+      ): any;
+      callback?: methodHandler;
+      get?: methodHandler;
+      head?: methodHandler;
+      options?: methodHandler;
+      del?: methodHandler;
+      delete?: methodHandler;
+      patch?: methodHandler;
+      post?: methodHandler;
+      put?: methodHandler;
+    };
+  }
+
+  type DisposeFunction = () => void;
+
+  function mockSuperagent(
+    request: SuperAgentStatic,
+    config: Array<mockSuperagent.MockConfig>,
+    logger?: Function
+  ): {unset: DisposeFunction};
+
+  export = mockSuperagent;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,6 +206,7 @@ importers:
       most: ^1.7.3
       rxjs: ^6.3.3
       superagent: ^3.8.3
+      superagent-mock: ^3.7.0
       symbol-observable: ^1.2.0
       ts-node: ^7.0.1
       tslint: ^5.11.0
@@ -217,6 +218,7 @@ importers:
       most: 1.7.3
       rxjs: 6.5.2
       superagent: 3.8.3
+      superagent-mock: 3.7.0_superagent@3.8.3
       xstream: 11.11.0
     devDependencies:
       '@cycle/isolate': link:../isolate
@@ -7186,6 +7188,14 @@ packages:
       mime: 1.6.0
       qs: 6.7.0
       readable-stream: 2.3.6
+    dev: false
+
+  /superagent-mock/3.7.0_superagent@3.8.3:
+    resolution: {integrity: sha512-+vWnpMgRw4X0tlN2c4SPbhoVG4RSdYdErJ4AiwCK0r2XqGbHvVNbpZlY0RBfzOy6F5eN5Q1+d1sncmakxnjbiQ==}
+    peerDependencies:
+      superagent: ^3.6.0
+    dependencies:
+      superagent: 3.8.3
     dev: false
 
   /supports-color/0.2.0:


### PR DESCRIPTION
/claim #567

Fixes #567.

This adds a mocked HTTP driver for tests. The helper wraps `superagent-mock`, maps the app's HTTP request stream through the existing HTTP response-stream path, and installs a catch-all mock that fails instead of letting an unexpected real request escape.

Changes included:
- export `mockHTTPDriver()` and its `MockConfig` type from `@cycle/http`
- reuse the existing request-to-response stream conversion so mocked responses keep the same `HTTPSource` shape as the real driver
- add local typings for `superagent-mock`
- add Node regression tests for a matched mock request and a missed mock config
- add `superagent-mock` to the HTTP package dependencies and lockfile

Verification run locally:
- `npx pnpm@7.33.7 --dir http run build-cjs`
- `npx pnpm@7.33.7 --dir http run build-es6`
- `npx pnpm@7.33.7 --dir http run lint`
- `npx pnpm@7.33.7 --dir http run test-node` -> 28 passing
- `git diff --check`

Note: `npx pnpm@7.33.7 install --frozen-lockfile --ignore-scripts` was also attempted, but this checkout hits an existing pnpm store/lock mismatch for the repo's `dox` GitHub tarball (`Expected package: dox@0.9.0. Actual package ... dox@1.0.0`) before it can validate the workspace install.