### PR TITLE
docs(examples): use time source debounce

### DIFF
--- a/examples/advanced/autocomplete-search/src/app.js
+++ b/examples/advanced/autocomplete-search/src/app.js
@@ -1,5 +1,4 @@
 import xs from 'xstream'
-import debounce from 'xstream/extra/debounce'
 import dropUntil from 'xstream/extra/dropUntil'
 import {ul, li, span, input, div, section, label} from '@cycle/dom'
 import Immutable from 'immutable'
@@ -132,7 +131,7 @@ function intent(domSource, timeSource) {
     keepFocusOnInput$:
       xs.merge(inputBlurToItem$, enterPressed$, tabPressed$),
     selectHighlighted$:
-      xs.merge(itemMouseClick$, enterPressed$, tabPressed$).compose(debounce(1)),
+      xs.merge(itemMouseClick$, enterPressed$, tabPressed$).compose(timeSource.debounce(1)),
     wantsSuggestions$:
       xs.merge(inputFocus$.mapTo(true), inputBlur$.mapTo(false)),
     quitAutocomplete$:

--- a/examples/intermediate/http-search-github/src/main.js
+++ b/examples/intermediate/http-search-github/src/main.js
@@ -1,5 +1,4 @@
 import xs from 'xstream';
-import debounce from 'xstream/extra/debounce';
 import {run} from '@cycle/run';
 import {div, label, input, hr, ul, li, a, makeDOMDriver} from '@cycle/dom';
 import {makeHTTPDriver} from '@cycle/http';


### PR DESCRIPTION
## Summary
- removes the remaining `xstream/extra/debounce` usage from official examples
- switches autocomplete selection debouncing to the existing `Time` source
- removes an unused debounce import from the GitHub search example

Contributes to #635 by addressing the checklist item to update official examples to avoid xstream time-related operators.

## Verification
- `rg -n xstream/extra/(debounce|delay|throttle)|xs\.periodic|\.compose\((debounce|delay|throttle) examples -g *.js -g *.ts` returns no matches
- `node --check examples/advanced/autocomplete-search/src/app.js`
- `node --check examples/intermediate/http-search-github/src/main.js`
- `git diff --check`