### PR TITLE
docs(dom): add API usage examples

### DIFF
--- a/docs/api/dom.html
+++ b/docs/api/dom.html
@@ -38,6 +38,59 @@ A Cycle.js driver to enable interaction with the DOM. The driver is based on [sn
 npm install @cycle/dom
 ```
 
+## Usage
+
+Use `makeDOMDriver()` to connect a stream of virtual DOM nodes to a real DOM
+element. The driver output is a DOM source, which you can query with
+`select()` and `events()`.
+
+```js
+import xs from 'xstream';
+import {run} from '@cycle/run';
+import {button, div, makeDOMDriver} from '@cycle/dom';
+
+function main(sources) {
+  const count$ = sources.DOM
+    .select('.increment')
+    .events('click')
+    .fold(count => count + 1, 0);
+
+  const vdom$ = count$.map(count =>
+    div([
+      button('.increment', 'Increment'),
+      div('.count', `Count: ${count}`),
+    ])
+  );
+
+  return {
+    DOM: vdom$,
+  };
+}
+
+run(main, {
+  DOM: makeDOMDriver('#app'),
+});
+```
+
+The `DOM` sink may emit any snabbdom `VNode` created with helpers from
+`@cycle/dom`, such as `div()`, `button()`, `input()`, or the generic `h()`
+function. `makeDOMDriver()` accepts either a CSS selector or an `Element` as
+its render target.
+
+When listening to user input, select the element first and then choose the DOM
+event:
+
+```js
+const input$ = sources.DOM
+  .select('.field')
+  .events('input')
+  .map(event => event.target.value);
+```
+
+If you use `document.body` as the render target, make the top-level VNode match
+the target element. For example, emit `body([...children])` when the driver is
+created with `makeDOMDriver(document.body)`.
+
 ## Browser support
 
 These are the browsers we officially test for:

--- a/docs/content/api/dom.md
+++ b/docs/content/api/dom.md
@@ -6,6 +6,59 @@ A Cycle.js driver to enable interaction with the DOM. The driver is based on [sn
 npm install @cycle/dom
 ```
 
+## Usage
+
+Use `makeDOMDriver()` to connect a stream of virtual DOM nodes to a real DOM
+element. The driver output is a DOM source, which you can query with
+`select()` and `events()`.
+
+```js
+import xs from 'xstream';
+import {run} from '@cycle/run';
+import {button, div, makeDOMDriver} from '@cycle/dom';
+
+function main(sources) {
+  const count$ = sources.DOM
+    .select('.increment')
+    .events('click')
+    .fold(count => count + 1, 0);
+
+  const vdom$ = count$.map(count =>
+    div([
+      button('.increment', 'Increment'),
+      div('.count', `Count: ${count}`),
+    ])
+  );
+
+  return {
+    DOM: vdom$,
+  };
+}
+
+run(main, {
+  DOM: makeDOMDriver('#app'),
+});
+```
+
+The `DOM` sink may emit any snabbdom `VNode` created with helpers from
+`@cycle/dom`, such as `div()`, `button()`, `input()`, or the generic `h()`
+function. `makeDOMDriver()` accepts either a CSS selector or an `Element` as
+its render target.
+
+When listening to user input, select the element first and then choose the DOM
+event:
+
+```js
+const input$ = sources.DOM
+  .select('.field')
+  .events('input')
+  .map(event => event.target.value);
+```
+
+If you use `document.body` as the render target, make the top-level VNode match
+the target element. For example, emit `body([...children])` when the driver is
+created with `makeDOMDriver(document.body)`.
+
 ## Browser support
 
 These are the browsers we officially test for:


### PR DESCRIPTION
Contributes to #851.

## What changed
- Adds a first-use `@cycle/dom` API example showing `makeDOMDriver()`, a DOM sink, and event selection with `select().events()`.
- Documents that the driver accepts either a selector or an `Element` render target.
- Notes the `document.body` top-level VNode requirement for body-mounted apps.
- Keeps the checked-in rendered `docs/api/dom.html` in sync with `docs/content/api/dom.md`.

## Verification
- `node --check .scripts/make-api-docs.js`
- `git diff --check`

## Note
I attempted to regenerate the DOM API page with `node .scripts/make-api-docs.js dom`, but the existing docs toolchain fails before writing output because the installed `dox` dependency throws `TypeError: parse is not a function`. I therefore mirrored the Markdown addition into the rendered HTML without changing the existing generated API block.