### PR TITLE
feat(time): support promise test completion

### DIFF
--- a/time/README.md
+++ b/time/README.md
@@ -249,7 +249,7 @@ We can also use `@cycle/time` to declaratively test time based operators such as
 import {mockTimeSource} from '@cycle/time';
 
 describe('@cycle/time delay', () => {
-  it('is super quick because of virtual time', (done) => {
+  it('is super quick because of virtual time', async () => {
     const Time = mockTimeSource();
 
     const input$    = Time.diagram('-1--------2---|');
@@ -258,7 +258,7 @@ describe('@cycle/time delay', () => {
 
     Time.assertEqual(actual$, expected$);
 
-    Time.run(done);
+    await Time.run();
   });
 });
 ```
@@ -429,10 +429,41 @@ Instead of all delays and debounces running in real time in your tests, causing 
 
 Has some additional methods that are useful for testing:
 
-#### `run(doneCallback = raiseError)`
-Executes the schedule. This should be called at the end of your test run. Takes a callback that takes an error as the first argument if an error occurs, such as an assertion failing.
+#### `run(doneCallback?)`
+Executes the schedule. This should be called at the end of your test run.
 
-If no callback is provided, errors will be raised.
+When a callback is provided, it receives an error as the first argument if an error occurs, such as an assertion failing. This supports callback-based test frameworks:
+
+<!-- skip-example -->
+```js
+it('checks a stream with callbacks', done => {
+  const Time = mockTimeSource();
+
+  Time.assertEqual(
+    Time.diagram('---1---2---3--|'),
+    Time.diagram('---1---2---3--|')
+  );
+
+  Time.run(done);
+});
+```
+
+When no callback is provided, `run()` returns a Promise. This supports promise-based and `async`/`await` test frameworks such as AVA, Mocha, and Jest:
+
+<!-- skip-example -->
+```js
+test('checks a stream with async/await', async t => {
+  const Time = mockTimeSource();
+
+  Time.assertEqual(
+    Time.diagram('---1---2---3--|'),
+    Time.diagram('---1---2---3--|')
+  );
+
+  await Time.run();
+  t.pass();
+});
+```
 
 #### `diagram(diagramString, values = {})`
 A constructor that takes a string representing a stream and returns a stream.

--- a/time/src/mock-time-source.ts
+++ b/time/src/mock-time-source.ts
@@ -107,7 +107,21 @@ function mockTimeSource({interval = 20} = {}): any {
       currentTime
     ),
 
-    run(doneCallback = raiseError, timeToRunTo = 0) {
+    run(doneCallback?: any, timeToRunTo = 0) {
+      if (typeof doneCallback === 'number') {
+        timeToRunTo = doneCallback;
+        doneCallback = undefined;
+      }
+
+      if (doneCallback === undefined) {
+        return new Promise((resolve, reject) => {
+          timeSource.run(
+            (err: any) => (err ? reject(err) : resolve()),
+            timeToRunTo
+          );
+        });
+      }
+
       done = doneCallback;
       if (!timeToRunTo) {
         timeToRunTo = maxTime;

--- a/time/src/most.ts
+++ b/time/src/most.ts
@@ -30,7 +30,9 @@ interface MockTimeSource extends TimeSource {
     expected: Stream<any>,
     comparator?: Comparator
   ): void;
-  run(cb?: (err?: Error) => void): void;
+  run(): Promise<void>;
+  run(timeToRunTo: number): Promise<void>;
+  run(cb: (err?: Error) => void, timeToRunTo?: number): void;
 }
 
 function mockTimeSource(args?: Object): MockTimeSource {

--- a/time/src/rxjs.ts
+++ b/time/src/rxjs.ts
@@ -30,7 +30,9 @@ interface MockTimeSource extends TimeSource {
     expected: Observable<any>,
     comparator?: Comparator
   ): void;
-  run(cb?: (err?: Error) => void): void;
+  run(): Promise<void>;
+  run(timeToRunTo: number): Promise<void>;
+  run(cb: (err?: Error) => void, timeToRunTo?: number): void;
 }
 
 function mockTimeSource(args?: Object): MockTimeSource {

--- a/time/src/time-source.ts
+++ b/time/src/time-source.ts
@@ -23,5 +23,7 @@ export interface MockTimeSource extends TimeSource {
     expected: Stream<any>,
     comparator?: Comparator
   ): void;
-  run(cb?: (err?: Error) => void): void;
+  run(): Promise<void>;
+  run(timeToRunTo: number): Promise<void>;
+  run(cb: (err?: Error) => void, timeToRunTo?: number): void;
 }

--- a/time/test/time.ts
+++ b/time/test/time.ts
@@ -194,6 +194,36 @@ describe('@cycle/time', () => {
       before(() => setAdapt(library.adapt));
 
       describe('mockTimeSource', () => {
+        it('supports promise-style test completion', () => {
+          const Time = mockTimeSource();
+
+          const actual = Time.diagram(`---1---2---3---|`);
+          const expected = Time.diagram(`---1---2---3---|`);
+
+          Time.assertEqual(actual, expected);
+
+          return Time.run();
+        });
+
+        it('rejects promise-style tests when an assertion fails', () => {
+          const Time = mockTimeSource();
+
+          const actual = Time.diagram(`---1---2---3---|`);
+          const expected = Time.diagram(`---1---2---4---|`);
+
+          Time.assertEqual(actual, expected);
+
+          return Time.run().then(
+            () => {
+              throw new Error('expected test to fail');
+            },
+            err => {
+              assert(err);
+              assert(err.message.indexOf('Expected') !== -1);
+            }
+          );
+        });
+
         describe('.diagram', () => {
           it('creates streams from ascii diagrams', done => {
             const Time = mockTimeSource();


### PR DESCRIPTION
## Summary
- make `mockTimeSource().run()` return a Promise when called without a callback, while preserving the existing callback form
- add overloads for xstream, RxJS, and most entrypoints so `await Time.run()` type-checks
- document both callback and async/await usage for test frameworks such as AVA

Fixes #765

## Verification
- `node_modules\.bin\tsc.cmd --module commonjs --outDir .\lib\cjs`
- `node_modules\.bin\tsc.cmd --module es6 --outDir .\lib\es6`
- `node_modules\.bin\tslint.cmd --project tsconfig.lint.json --config ..\tslint.json`
- `node_modules\.bin\markdown-doctest.CMD` (21 passed, 7 skipped)
- `node_modules\.bin\mocha.cmd test/time.ts --require ts-node/register --grep promise-style --exit` (6 passing)
- `git diff --check`

Note: the full `node_modules\.bin\mocha.cmd test/**/*.ts --require ts-node/register --exit` run reaches 118 passing tests including the new promise tests, then fails 12 existing unsubscribe timing assertions with the same `[0, 1]` vs `[0]` pattern across xstream/RxJS/most on this Windows + Node 22 environment. The focused promise tests pass independently.