### PR TITLE
Expand HTTP driver docs

### DIFF
--- a/docs/api/http.html
+++ b/docs/api/http.html
@@ -40,11 +40,14 @@ npm install @cycle/http
 
 ## Usage
 
-Basics:
+Create the driver with `makeHTTPDriver()` and provide it under the `HTTP`
+key. The app sends request objects to the `HTTP` sink and reads responses from
+the `HTTP` source.
 
 ```js
 import xs from 'xstream';
 import {run} from '@cycle/run';
+import {button, div, h1, makeDOMDriver} from '@cycle/dom';
 import {makeHTTPDriver} from '@cycle/http';
 
 function main(sources) {
@@ -52,111 +55,262 @@ function main(sources) {
 }
 
 const drivers = {
-  HTTP: makeHTTPDriver()
-}
+  DOM: makeDOMDriver('#app'),
+  HTTP: makeHTTPDriver(),
+};
 
 run(main, drivers);
 ```
 
-Simple and normal use case:
+### Basic request and response flow
+
+The HTTP sink can emit either a URL string or a request object. A request object
+must have `url`; all other options are passed to Superagent.
 
 ```js
 function main(sources) {
-  let request$ = xs.of({
+  const request$ = xs.of({
     url: 'http://localhost:8080/hello', // GET method by default
     category: 'hello',
   });
 
-  let response$ = sources.HTTP
+  const response$ = sources.HTTP
     .select('hello')
     .flatten();
 
-  let vdom$ = response$
-    .map(res => res.text) // We expect this to be "Hello World"
+  const vdom$ = response$
+    .map(res => res.text)
     .startWith('Loading...')
     .map(text =>
       div('.container', [
-        h1(text)
+        h1(text),
       ])
     );
 
   return {
     DOM: vdom$,
-    HTTP: request$
+    HTTP: request$,
   };
 }
 ```
 
-A thorough guide to the API inside `main`:
+### Request options
+
+These examples cover the most common request shapes:
 
 ```js
-function main(source) {
-  // The HTTP Source has properties:
-  // - select(category) or select()
-  // - filter(predicate)
-  // Notice $$: it means this is a metastream, in other words,
-  // a stream of streams.
-  let httpResponse$$ = source.HTTP.select();
+const getUser$ = xs.of({
+  url: '/api/users/42',
+  category: 'user',
+  query: {include: 'profile'},
+  headers: {'X-Client': 'cycle'},
+});
 
-  httpResponse$$.addListener({
-    next: httpResponse$ => {
-      // Notice that httpResponse$$ emits httpResponse$.
+const createUser$ = xs.of({
+  url: '/api/users',
+  method: 'POST',
+  category: 'user',
+  send: {name: 'Ada'},
+  type: 'json',
+  accept: 'json',
+});
 
-      // The response stream has a special field attached to it:
-      // `request`, which is the same object we emit in the sink stream.
-      // This is useful for filtering: you can find the
-      // httpResponse$ corresponding to a certain request.
-      console.log(httpResponse$.request);
-    },
-    error: () => {},
-    complete: () => {},
-  });
+const avatarData = new FormData();
+avatarData.append('avatar', fileInput.files[0]);
 
-  let httpResponse$ = httpResponse$$.flatten(); // flattens the metastream
-  // the reason why we need to flatten in this API is that you
-  // should choose which concurrency strategy to use.
-  // Normal xstream flatten() has limited concurrency of 1, meaning that
-  // the previous request will be canceled once the next request to the
-  // same resource occurs.
-  // To have full concurrency (no cancelling), use flattenConcurrently()
+const uploadAvatar$ = xs.of({
+  url: '/api/avatar',
+  method: 'POST',
+  category: 'avatar',
+  send: avatarData,
+  progress: true,
+});
+```
 
-  httpResponse$.addListener({
-    next: httpResponse => {
-      // httpResponse is the object we get as response from superagent.
-      // Check the documentation in superagent to know the structure of
-      // this object.
-      console.log(httpResponse.status); // 200
-    },
-    error: (err) => {
-      // This is a network error
-      console.error(err);
-    },
-    complete: () => {},
-  });
+When sending `FormData`, do not set `Content-Type` manually. Superagent will add
+the multipart boundary for you.
 
-  // The request stream is an object with property `url` and value
-  // `http://localhost:8080/ping` emitted periodically, every second.
-  let request$ = xs.periodic(1000)
-    .mapTo({ url: 'http://localhost:8080/ping', method: 'GET' });
+The request stream returned in the sink is often created from user events:
+
+```js
+const searchRequest$ = sources.DOM.select('.search').events('input')
+  .map(event => event.target.value)
+  .filter(query => query.length >= 3)
+  .map(query => ({
+    url: 'https://api.github.com/search/repositories',
+    category: 'github-search',
+    query: {q: query},
+  }));
+```
+
+### Selecting responses
+
+`sources.HTTP.select(category)` returns a stream of response streams. In Cycle.js
+docs, a variable name ending in `$$` means that it is a stream of streams.
+
+Each inner response stream has a `request` field, which is the normalized request
+that produced the response. You can use it to inspect metadata or match a
+response to its request.
+
+```js
+const response$$ = sources.HTTP.select('github-search');
+
+response$$.addListener({
+  next: response$ => {
+    console.log(response$.request.category); // 'github-search'
+    console.log(response$.request.url);
+  },
+  error: () => {},
+  complete: () => {},
+});
+```
+
+To read the actual Superagent responses, flatten the response metastream:
+
+```js
+const response$ = sources.HTTP
+  .select('github-search')
+  .flatten();
+
+const result$ = response$
+  .map(response => response.body.items);
+```
+
+`flatten()` uses xstream's normal limited-concurrency behavior: if a new inner
+response stream arrives before the previous one completes, the previous request
+is cancelled. This is useful for live search where old results should be
+ignored.
+
+Use `flattenConcurrently()` when every request should be allowed to finish:
+
+```js
+const saveResponse$ = sources.HTTP
+  .select('save')
+  .flattenConcurrently();
+```
+
+When you need custom filtering, use `HTTPSource.filter()` before `select()`:
+
+```js
+const writeResponse$ = sources.HTTP
+  .filter(request => request.method === 'POST' || request.method === 'PUT')
+  .select()
+  .flattenConcurrently();
+```
+
+### Full example
+
+```js
+function main(sources) {
+  const request$ = sources.DOM.select('.refresh').events('click')
+    .startWith(null)
+    .mapTo({
+      url: 'https://jsonplaceholder.typicode.com/users/1',
+      category: 'user',
+      accept: 'json',
+    });
+
+  const user$ = sources.HTTP.select('user')
+    .flatten()
+    .map(response => response.body)
+    .startWith(null);
+
+  const vdom$ = user$.map(user =>
+    div([
+      button('.refresh', 'Refresh'),
+      user === null
+        ? h1('Loading...')
+        : h1(user.name),
+    ])
+  );
 
   return {
-    HTTP: request$ // HTTP driver expects the request$ as input
+    DOM: vdom$,
+    HTTP: request$,
   };
 }
 ```
 
 ## Error handling
 
-You can handle errors using standard xstream or RxJS operators. The response stream is a stream of streams, i.e. each response will be its own stream so usually you want to catch errors for that single response stream:
+Handle errors on each inner response stream. If you only handle errors after
+flattening, an HTTP error can end the whole flattened response stream.
 
 ```js
-sources.HTTP
-  .select('hello')
-  .map((response$) =>
-    response$.replaceError(() => xs.of(errorObject))
-  ).flatten()
+const user$ = sources.HTTP
+  .select('user')
+  .map(response$ =>
+    response$
+      .map(response => ({type: 'success', body: response.body}))
+      .replaceError(error => xs.of({type: 'failure', error}))
+  )
+  .flatten();
 ```
-For more information, refer to the [xstream documentation for replaceError](https://github.com/staltz/xstream#replaceError) or the [RxJS documention for catch](https://github.com/Reactive-Extensions/RxJS/blob/master/doc/api/core/operators/catch.md).
+
+For RxJS, use `catchError()` on the inner observable:
+
+```js
+const user$ = sources.HTTP
+  .select('user')
+  .pipe(
+    map(response$ =>
+      response$.pipe(
+        map(response => ({type: 'success', body: response.body})),
+        catchError(error => of({type: 'failure', error}))
+      )
+    ),
+    switchAll()
+  );
+```
+
+For more information, refer to the [xstream documentation for replaceError](https://github.com/staltz/xstream#replaceError) or the [RxJS documentation for catchError](https://rxjs.dev/api/operators/catchError).
+
+## Isolation semantics
+
+Cycle HTTP supports isolation between components using the `@cycle/isolate`
+package. Isolation scopes are stored on outgoing requests and are used to filter
+incoming response streams.
+
+**When the scope is `null`: no isolation.**
+
+The child component runs in the same HTTP context as its parent, so calls such as
+`HTTPSource.select()` can see response streams from the parent and siblings.
+
+**When the scope is a string: sibling isolation.**
+
+The parent can still see HTTP responses from its children, but an isolated child
+cannot see responses from siblings isolated with other scopes.
+
+```js
+import isolate from '@cycle/isolate';
+
+function UserCard(sources) {
+  const request$ = xs.of({
+    url: '/api/users/42',
+    category: 'user',
+  });
+
+  const name$ = sources.HTTP.select('user')
+    .flatten()
+    .map(response => response.body.name)
+    .startWith('Loading...');
+
+  return {
+    DOM: name$.map(name => div(name)),
+    HTTP: request$,
+  };
+}
+
+const IsolatedUserCard = isolate(UserCard, {HTTP: 'user-card-42'});
+```
+
+For multiple instances of the same component, give each instance a distinct HTTP
+scope so their requests and responses do not collide.
+
+```js
+const FirstUser = isolate(UserCard, {HTTP: 'user-1'});
+const SecondUser = isolate(UserCard, {HTTP: 'user-2'});
+```
 
 ## More information
 
@@ -168,20 +322,7 @@ For a more advanced usage, check the [Search example](https://github.com/cyclejs
 
 IE 8 is not supported because this library depends on [superagent](https://github.com/visionmedia/superagent), which knowingly doesn't support IE 8.
 
-# Isolation semantics
-
-Cycle HTTP supports isolation between components using the `@cycle/isolate` package. Here is how isolation contexts work in Cycle HTTP given a `scope` to `isolate(Component, scope)`:
-
-**When the scope is `null`: no isolation.**
-
-The child component will have run in the same context as its parent, and methods like `HTTPSource.select()` will have access to response streams related to the parent. This means the child component is able to see responses that it did not itself produce.
-
-**When the scope is a string: siblings isolation.**
-
-A `HTTPSource.select()` call in a parent component will have access to HTTP responses from its children. However, a `HTTPSource.select()` inside a child component isolated with "siblings isolation" will have no access to HTTP responses in other children components isolated with "siblings isolation".
-
 # API
-
 
 ## <a id="makeHTTPDriver"></a> `makeHTTPDriver()`
 

--- a/docs/content/api/http.md
+++ b/docs/content/api/http.md
@@ -8,11 +8,14 @@ npm install @cycle/http
 
 ## Usage
 
-Basics:
+Create the driver with `makeHTTPDriver()` and provide it under the `HTTP`
+key. The app sends request objects to the `HTTP` sink and reads responses from
+the `HTTP` source.
 
 ```js
 import xs from 'xstream';
 import {run} from '@cycle/run';
+import {button, div, h1, makeDOMDriver} from '@cycle/dom';
 import {makeHTTPDriver} from '@cycle/http';
 
 function main(sources) {
@@ -20,111 +23,262 @@ function main(sources) {
 }
 
 const drivers = {
-  HTTP: makeHTTPDriver()
-}
+  DOM: makeDOMDriver('#app'),
+  HTTP: makeHTTPDriver(),
+};
 
 run(main, drivers);
 ```
 
-Simple and normal use case:
+### Basic request and response flow
+
+The HTTP sink can emit either a URL string or a request object. A request object
+must have `url`; all other options are passed to Superagent.
 
 ```js
 function main(sources) {
-  let request$ = xs.of({
+  const request$ = xs.of({
     url: 'http://localhost:8080/hello', // GET method by default
     category: 'hello',
   });
 
-  let response$ = sources.HTTP
+  const response$ = sources.HTTP
     .select('hello')
     .flatten();
 
-  let vdom$ = response$
-    .map(res => res.text) // We expect this to be "Hello World"
+  const vdom$ = response$
+    .map(res => res.text)
     .startWith('Loading...')
     .map(text =>
       div('.container', [
-        h1(text)
+        h1(text),
       ])
     );
 
   return {
     DOM: vdom$,
-    HTTP: request$
+    HTTP: request$,
   };
 }
 ```
 
-A thorough guide to the API inside `main`:
+### Request options
+
+These examples cover the most common request shapes:
 
 ```js
-function main(source) {
-  // The HTTP Source has properties:
-  // - select(category) or select()
-  // - filter(predicate)
-  // Notice $$: it means this is a metastream, in other words,
-  // a stream of streams.
-  let httpResponse$$ = source.HTTP.select();
+const getUser$ = xs.of({
+  url: '/api/users/42',
+  category: 'user',
+  query: {include: 'profile'},
+  headers: {'X-Client': 'cycle'},
+});
 
-  httpResponse$$.addListener({
-    next: httpResponse$ => {
-      // Notice that httpResponse$$ emits httpResponse$.
+const createUser$ = xs.of({
+  url: '/api/users',
+  method: 'POST',
+  category: 'user',
+  send: {name: 'Ada'},
+  type: 'json',
+  accept: 'json',
+});
 
-      // The response stream has a special field attached to it:
-      // `request`, which is the same object we emit in the sink stream.
-      // This is useful for filtering: you can find the
-      // httpResponse$ corresponding to a certain request.
-      console.log(httpResponse$.request);
-    },
-    error: () => {},
-    complete: () => {},
-  });
+const avatarData = new FormData();
+avatarData.append('avatar', fileInput.files[0]);
 
-  let httpResponse$ = httpResponse$$.flatten(); // flattens the metastream
-  // the reason why we need to flatten in this API is that you
-  // should choose which concurrency strategy to use.
-  // Normal xstream flatten() has limited concurrency of 1, meaning that
-  // the previous request will be canceled once the next request to the
-  // same resource occurs.
-  // To have full concurrency (no cancelling), use flattenConcurrently()
+const uploadAvatar$ = xs.of({
+  url: '/api/avatar',
+  method: 'POST',
+  category: 'avatar',
+  send: avatarData,
+  progress: true,
+});
+```
 
-  httpResponse$.addListener({
-    next: httpResponse => {
-      // httpResponse is the object we get as response from superagent.
-      // Check the documentation in superagent to know the structure of
-      // this object.
-      console.log(httpResponse.status); // 200
-    },
-    error: (err) => {
-      // This is a network error
-      console.error(err);
-    },
-    complete: () => {},
-  });
+When sending `FormData`, do not set `Content-Type` manually. Superagent will add
+the multipart boundary for you.
 
-  // The request stream is an object with property `url` and value
-  // `http://localhost:8080/ping` emitted periodically, every second.
-  let request$ = xs.periodic(1000)
-    .mapTo({ url: 'http://localhost:8080/ping', method: 'GET' });
+The request stream returned in the sink is often created from user events:
+
+```js
+const searchRequest$ = sources.DOM.select('.search').events('input')
+  .map(event => event.target.value)
+  .filter(query => query.length >= 3)
+  .map(query => ({
+    url: 'https://api.github.com/search/repositories',
+    category: 'github-search',
+    query: {q: query},
+  }));
+```
+
+### Selecting responses
+
+`sources.HTTP.select(category)` returns a stream of response streams. In Cycle.js
+docs, a variable name ending in `$$` means that it is a stream of streams.
+
+Each inner response stream has a `request` field, which is the normalized request
+that produced the response. You can use it to inspect metadata or match a
+response to its request.
+
+```js
+const response$$ = sources.HTTP.select('github-search');
+
+response$$.addListener({
+  next: response$ => {
+    console.log(response$.request.category); // 'github-search'
+    console.log(response$.request.url);
+  },
+  error: () => {},
+  complete: () => {},
+});
+```
+
+To read the actual Superagent responses, flatten the response metastream:
+
+```js
+const response$ = sources.HTTP
+  .select('github-search')
+  .flatten();
+
+const result$ = response$
+  .map(response => response.body.items);
+```
+
+`flatten()` uses xstream's normal limited-concurrency behavior: if a new inner
+response stream arrives before the previous one completes, the previous request
+is cancelled. This is useful for live search where old results should be
+ignored.
+
+Use `flattenConcurrently()` when every request should be allowed to finish:
+
+```js
+const saveResponse$ = sources.HTTP
+  .select('save')
+  .flattenConcurrently();
+```
+
+When you need custom filtering, use `HTTPSource.filter()` before `select()`:
+
+```js
+const writeResponse$ = sources.HTTP
+  .filter(request => request.method === 'POST' || request.method === 'PUT')
+  .select()
+  .flattenConcurrently();
+```
+
+### Full example
+
+```js
+function main(sources) {
+  const request$ = sources.DOM.select('.refresh').events('click')
+    .startWith(null)
+    .mapTo({
+      url: 'https://jsonplaceholder.typicode.com/users/1',
+      category: 'user',
+      accept: 'json',
+    });
+
+  const user$ = sources.HTTP.select('user')
+    .flatten()
+    .map(response => response.body)
+    .startWith(null);
+
+  const vdom$ = user$.map(user =>
+    div([
+      button('.refresh', 'Refresh'),
+      user === null
+        ? h1('Loading...')
+        : h1(user.name),
+    ])
+  );
 
   return {
-    HTTP: request$ // HTTP driver expects the request$ as input
+    DOM: vdom$,
+    HTTP: request$,
   };
 }
 ```
 
 ## Error handling
 
-You can handle errors using standard xstream or RxJS operators. The response stream is a stream of streams, i.e. each response will be its own stream so usually you want to catch errors for that single response stream:
+Handle errors on each inner response stream. If you only handle errors after
+flattening, an HTTP error can end the whole flattened response stream.
 
 ```js
-sources.HTTP
-  .select('hello')
-  .map((response$) =>
-    response$.replaceError(() => xs.of(errorObject))
-  ).flatten()
+const user$ = sources.HTTP
+  .select('user')
+  .map(response$ =>
+    response$
+      .map(response => ({type: 'success', body: response.body}))
+      .replaceError(error => xs.of({type: 'failure', error}))
+  )
+  .flatten();
 ```
-For more information, refer to the [xstream documentation for replaceError](https://github.com/staltz/xstream#replaceError) or the [RxJS documention for catch](https://github.com/Reactive-Extensions/RxJS/blob/master/doc/api/core/operators/catch.md).
+
+For RxJS, use `catchError()` on the inner observable:
+
+```js
+const user$ = sources.HTTP
+  .select('user')
+  .pipe(
+    map(response$ =>
+      response$.pipe(
+        map(response => ({type: 'success', body: response.body})),
+        catchError(error => of({type: 'failure', error}))
+      )
+    ),
+    switchAll()
+  );
+```
+
+For more information, refer to the [xstream documentation for replaceError](https://github.com/staltz/xstream#replaceError) or the [RxJS documentation for catchError](https://rxjs.dev/api/operators/catchError).
+
+## Isolation semantics
+
+Cycle HTTP supports isolation between components using the `@cycle/isolate`
+package. Isolation scopes are stored on outgoing requests and are used to filter
+incoming response streams.
+
+**When the scope is `null`: no isolation.**
+
+The child component runs in the same HTTP context as its parent, so calls such as
+`HTTPSource.select()` can see response streams from the parent and siblings.
+
+**When the scope is a string: sibling isolation.**
+
+The parent can still see HTTP responses from its children, but an isolated child
+cannot see responses from siblings isolated with other scopes.
+
+```js
+import isolate from '@cycle/isolate';
+
+function UserCard(sources) {
+  const request$ = xs.of({
+    url: '/api/users/42',
+    category: 'user',
+  });
+
+  const name$ = sources.HTTP.select('user')
+    .flatten()
+    .map(response => response.body.name)
+    .startWith('Loading...');
+
+  return {
+    DOM: name$.map(name => div(name)),
+    HTTP: request$,
+  };
+}
+
+const IsolatedUserCard = isolate(UserCard, {HTTP: 'user-card-42'});
+```
+
+For multiple instances of the same component, give each instance a distinct HTTP
+scope so their requests and responses do not collide.
+
+```js
+const FirstUser = isolate(UserCard, {HTTP: 'user-1'});
+const SecondUser = isolate(UserCard, {HTTP: 'user-2'});
+```
 
 ## More information
 
@@ -135,17 +289,5 @@ For a more advanced usage, check the [Search example](https://github.com/cyclejs
 [![Sauce Test Status](https://saucelabs.com/browser-matrix/cyclejs-http.svg)](https://saucelabs.com/u/cyclejs-http)
 
 IE 8 is not supported because this library depends on [superagent](https://github.com/visionmedia/superagent), which knowingly doesn't support IE 8.
-
-# Isolation semantics
-
-Cycle HTTP supports isolation between components using the `@cycle/isolate` package. Here is how isolation contexts work in Cycle HTTP given a `scope` to `isolate(Component, scope)`:
-
-**When the scope is `null`: no isolation.**
-
-The child component will have run in the same context as its parent, and methods like `HTTPSource.select()` will have access to response streams related to the parent. This means the child component is able to see responses that it did not itself produce.
-
-**When the scope is a string: siblings isolation.**
-
-A `HTTPSource.select()` call in a parent component will have access to HTTP responses from its children. However, a `HTTPSource.select()` inside a child component isolated with "siblings isolation" will have no access to HTTP responses in other children components isolated with "siblings isolation".
 
 # API


### PR DESCRIPTION
/claim #851

Contributes to #851.

This adds another focused docs-revamp slice for `@cycle/http`. It expands the HTTP API page with:

- driver setup with the DOM driver included in the example
- basic request/response flow using categories
- common request object shapes for GET, POST, headers, query, upload, and progress
- guidance on `select()`, response metastreams, the `response$.request` field, `flatten()`, and `flattenConcurrently()`
- examples for custom `HTTPSource.filter()` usage
- xstream and RxJS error-handling examples on inner response streams
- HTTP isolation semantics with a component example

I also mirrored the Markdown content into the checked-in `docs/api/http.html` wrapper because the docs generator is currently blocked in this checkout.

Verification run locally:
- `node --check .scripts/make-api-docs.js`
- `git diff --check`
- embedded-markdown consistency check between `docs/content/api/http.md` and `docs/api/http.html`

I also tried regenerating the rendered API HTML with:
- `node .scripts/make-api-docs.js http`

That fails in the existing docs toolchain because the installed GitHub tarball for `dox` throws `TypeError: parse is not a function`, matching the same pre-existing generator failure seen on the other docs-revamp branches.