### PR TITLE
Expand run package docs

### DIFF
--- a/docs/api/most-run.html
+++ b/docs/api/most-run.html
@@ -32,7 +32,8 @@
   <script id="markdown" type="text/markdown" src="index.html">
 # Run() for most.js - [source](https://github.com/cyclejs/cyclejs/tree/master/most-run)
 
-Cycle.js `run(main, drivers)` function for applications written with most.js (Monadic Streams)
+Cycle.js `run(main, drivers)` function for applications written with most.js
+(Monadic Streams).
 
 ```
 npm install @cycle/most-run most
@@ -43,26 +44,102 @@ npm install @cycle/most-run most
 ## Basic usage
 
 ```js
-import run from '@cycle/most-run'
+import run from '@cycle/most-run';
+import {button} from '@cycle/dom';
 
-run(main, drivers)
+function main(sources) {
+  const action$ = sources.DOM.select('button').events('click');
+  const count$ = action$.scan((count, _event) => count + 1, 0).startWith(0);
+
+  return {
+    DOM: count$.map(count => button(String(count))),
+  };
+}
+
+const dispose = run(main, drivers);
 ```
+
+`run()` immediately starts the application and returns a dispose function. Call
+that function when the application should stop listening to sources, stop
+replicating sinks to drivers, and release driver resources.
+
+```js
+const dispose = run(main, drivers);
+
+// Later:
+dispose();
+```
+
+## Main and drivers
+
+`main` receives driver sources as most.js streams and returns sinks as most.js
+streams:
+
+```js
+function main(sources) {
+  return {
+    DOM: vdom$,
+    HTTP: request$,
+  };
+}
+```
+
+`drivers` is still an object where each key matches a sink and source channel:
+
+```js
+const drivers = {
+  DOM: makeDOMDriver('#app'),
+  HTTP: makeHTTPDriver(),
+};
+```
+
+Internally, `@cycle/most-run` delegates to `@cycle/run` and adapts between
+xstream streams used by drivers and most.js streams used by the application.
+
+## setup()
+
+Use `setup()` when you need access to `sources` and `sinks` before starting the
+program. This is useful in tests, integration code, or custom bootstrapping.
+
+```js
+import {setup} from '@cycle/most-run';
+
+const {sources, sinks, run} = setup(main, drivers);
+
+// Inspect sources or sinks here before the program starts.
+
+const dispose = run();
+```
+
+Unlike `run(main, drivers)`, `setup(main, drivers)` does not start execution
+until you call the returned `run()` function.
 
 ## Testing usage
 
+`setup()` also lets tests subscribe to sources or sinks before starting the
+program:
+
 ```js
-import {setup} from '@cycle/most-run'
+import {setup} from '@cycle/most-run';
 
-const {sources, sinks, run} = setup(main, drivers)
+const {sources, run} = setup(main, drivers);
 
-let dispose
+const observed = sources.DOM.select(':root').elements
+  .observe(element => {
+    // assert against the rendered root element
+  });
 
-sources.DOM.select(':root').elements
-  .observe(fn)
-  .then(() => dispose())
+const dispose = run();
 
-dispose = run() // start the loop
+observed.then(() => dispose());
 ```
+
+## most.js expectations
+
+Use `@cycle/most-run` when your `main` function is written with most.js streams.
+Driver packages such as `@cycle/dom` and `@cycle/http` can still be the same
+official drivers; this package handles the stream adaptation at the app
+boundary.
 
 # API
 

--- a/docs/api/run.html
+++ b/docs/api/run.html
@@ -43,10 +43,103 @@ npm install @cycle/run xstream
 ## Basic usage
 
 ```js
-import {run} from '@cycle/run'
+import {run} from '@cycle/run';
+import {button} from '@cycle/dom';
 
-run(main, drivers)
+function main(sources) {
+  const action$ = sources.DOM.select('button').events('click');
+  const count$ = action$.fold(count => count + 1, 0);
+
+  return {
+    DOM: count$.map(count => button(String(count))),
+  };
+}
+
+const dispose = run(main, drivers);
 ```
+
+`run()` immediately starts the application and returns a dispose function. Call
+that function when the application should stop listening to sources, stop
+replicating sinks to drivers, and release driver resources.
+
+```js
+const dispose = run(main, drivers);
+
+// Later:
+dispose();
+```
+
+## Main and drivers
+
+`main` is the pure part of a Cycle.js program. It receives sources from drivers
+and returns sinks for those drivers:
+
+```js
+function main(sources) {
+  return {
+    DOM: vdom$,
+    HTTP: request$,
+  };
+}
+```
+
+`drivers` is an object where each key matches a sink and source channel. Driver
+functions receive a sink stream and return a source:
+
+```js
+const drivers = {
+  DOM: makeDOMDriver('#app'),
+  HTTP: makeHTTPDriver(),
+};
+```
+
+The `DOM` sink is consumed by the DOM driver and `sources.DOM` is returned to
+`main`. The same pattern applies to every driver.
+
+## setup()
+
+Use `setup()` when you need access to `sources` and `sinks` before starting the
+program. This is useful in tests, integration code, or custom bootstrapping.
+
+```js
+import {setup} from '@cycle/run';
+
+const {sources, sinks, run} = setup(main, drivers);
+
+// Inspect sources or sinks here before the program starts.
+
+const dispose = run();
+```
+
+Unlike `run(main, drivers)`, `setup(main, drivers)` does not start execution
+until you call the returned `run()` function.
+
+## setupReusable()
+
+Use `setupReusable()` when you want to create driver sources once and run
+multiple sink collections through the same driver set.
+
+```js
+import {setupReusable} from '@cycle/run';
+
+const engine = setupReusable(drivers);
+
+const firstDispose = engine.run(firstMain(engine.sources));
+firstDispose();
+
+const secondDispose = engine.run(secondMain(engine.sources));
+secondDispose();
+
+engine.dispose();
+```
+
+Call `engine.dispose()` when you are done reusing those drivers.
+
+## xstream expectations
+
+`@cycle/run` expects sink streams to be xstream streams. If you use another
+stream library for your application code, use `@cycle/rxjs-run` or
+`@cycle/most-run` instead so that source and sink streams are adapted correctly.
 
 # API
 

--- a/docs/api/rxjs-run.html
+++ b/docs/api/rxjs-run.html
@@ -43,10 +43,82 @@ npm install @cycle/rxjs-run rxjs
 ## Basic usage
 
 ```js
-import run from '@cycle/rxjs-run'
+import run from '@cycle/rxjs-run';
+import {button} from '@cycle/dom';
 
-run(main, drivers)
+function main(sources) {
+  const action$ = sources.DOM.select('button').events('click');
+  const count$ = action$.scan(count => count + 1, 0).startWith(0);
+
+  return {
+    DOM: count$.map(count => button(String(count))),
+  };
+}
+
+const dispose = run(main, drivers);
 ```
+
+`run()` immediately starts the application and returns a dispose function. Call
+that function when the application should stop listening to sources, stop
+replicating sinks to drivers, and release driver resources.
+
+```js
+const dispose = run(main, drivers);
+
+// Later:
+dispose();
+```
+
+## Main and drivers
+
+`main` receives driver sources as RxJS observables and returns sinks as RxJS
+observables:
+
+```js
+function main(sources) {
+  return {
+    DOM: vdom$,
+    HTTP: request$,
+  };
+}
+```
+
+`drivers` is still an object where each key matches a sink and source channel:
+
+```js
+const drivers = {
+  DOM: makeDOMDriver('#app'),
+  HTTP: makeHTTPDriver(),
+};
+```
+
+Internally, `@cycle/rxjs-run` delegates to `@cycle/run` and adapts between
+xstream streams used by drivers and RxJS observables used by the application.
+
+## setup()
+
+Use `setup()` when you need access to `sources` and `sinks` before starting the
+program. This is useful in tests, integration code, or custom bootstrapping.
+
+```js
+import {setup} from '@cycle/rxjs-run';
+
+const {sources, sinks, run} = setup(main, drivers);
+
+// Inspect sources or sinks here before the program starts.
+
+const dispose = run();
+```
+
+Unlike `run(main, drivers)`, `setup(main, drivers)` does not start execution
+until you call the returned `run()` function.
+
+## RxJS expectations
+
+Use `@cycle/rxjs-run` when your `main` function is written with RxJS streams.
+Driver packages such as `@cycle/dom` and `@cycle/http` can still be the same
+official drivers; this package handles the stream adaptation at the app
+boundary.
 
 # API
 

--- a/docs/content/api/most-run.md
+++ b/docs/content/api/most-run.md
@@ -1,6 +1,7 @@
 # Run() for most.js - [source](https://github.com/cyclejs/cyclejs/tree/master/most-run)
 
-Cycle.js `run(main, drivers)` function for applications written with most.js (Monadic Streams)
+Cycle.js `run(main, drivers)` function for applications written with most.js
+(Monadic Streams).
 
 ```
 npm install @cycle/most-run most
@@ -11,25 +12,101 @@ npm install @cycle/most-run most
 ## Basic usage
 
 ```js
-import run from '@cycle/most-run'
+import run from '@cycle/most-run';
+import {button} from '@cycle/dom';
 
-run(main, drivers)
+function main(sources) {
+  const action$ = sources.DOM.select('button').events('click');
+  const count$ = action$.scan((count, _event) => count + 1, 0).startWith(0);
+
+  return {
+    DOM: count$.map(count => button(String(count))),
+  };
+}
+
+const dispose = run(main, drivers);
 ```
+
+`run()` immediately starts the application and returns a dispose function. Call
+that function when the application should stop listening to sources, stop
+replicating sinks to drivers, and release driver resources.
+
+```js
+const dispose = run(main, drivers);
+
+// Later:
+dispose();
+```
+
+## Main and drivers
+
+`main` receives driver sources as most.js streams and returns sinks as most.js
+streams:
+
+```js
+function main(sources) {
+  return {
+    DOM: vdom$,
+    HTTP: request$,
+  };
+}
+```
+
+`drivers` is still an object where each key matches a sink and source channel:
+
+```js
+const drivers = {
+  DOM: makeDOMDriver('#app'),
+  HTTP: makeHTTPDriver(),
+};
+```
+
+Internally, `@cycle/most-run` delegates to `@cycle/run` and adapts between
+xstream streams used by drivers and most.js streams used by the application.
+
+## setup()
+
+Use `setup()` when you need access to `sources` and `sinks` before starting the
+program. This is useful in tests, integration code, or custom bootstrapping.
+
+```js
+import {setup} from '@cycle/most-run';
+
+const {sources, sinks, run} = setup(main, drivers);
+
+// Inspect sources or sinks here before the program starts.
+
+const dispose = run();
+```
+
+Unlike `run(main, drivers)`, `setup(main, drivers)` does not start execution
+until you call the returned `run()` function.
 
 ## Testing usage
 
+`setup()` also lets tests subscribe to sources or sinks before starting the
+program:
+
 ```js
-import {setup} from '@cycle/most-run'
+import {setup} from '@cycle/most-run';
 
-const {sources, sinks, run} = setup(main, drivers)
+const {sources, run} = setup(main, drivers);
 
-let dispose
+const observed = sources.DOM.select(':root').elements
+  .observe(element => {
+    // assert against the rendered root element
+  });
 
-sources.DOM.select(':root').elements
-  .observe(fn)
-  .then(() => dispose())
+const dispose = run();
 
-dispose = run() // start the loop
+observed.then(() => dispose());
 ```
+
+## most.js expectations
+
+Use `@cycle/most-run` when your `main` function is written with most.js streams.
+Driver packages such as `@cycle/dom` and `@cycle/http` can still be the same
+official drivers; this package handles the stream adaptation at the app
+boundary.
 
 # API

--- a/docs/content/api/run.md
+++ b/docs/content/api/run.md
@@ -11,9 +11,102 @@ npm install @cycle/run xstream
 ## Basic usage
 
 ```js
-import {run} from '@cycle/run'
+import {run} from '@cycle/run';
+import {button} from '@cycle/dom';
 
-run(main, drivers)
+function main(sources) {
+  const action$ = sources.DOM.select('button').events('click');
+  const count$ = action$.fold(count => count + 1, 0);
+
+  return {
+    DOM: count$.map(count => button(String(count))),
+  };
+}
+
+const dispose = run(main, drivers);
 ```
+
+`run()` immediately starts the application and returns a dispose function. Call
+that function when the application should stop listening to sources, stop
+replicating sinks to drivers, and release driver resources.
+
+```js
+const dispose = run(main, drivers);
+
+// Later:
+dispose();
+```
+
+## Main and drivers
+
+`main` is the pure part of a Cycle.js program. It receives sources from drivers
+and returns sinks for those drivers:
+
+```js
+function main(sources) {
+  return {
+    DOM: vdom$,
+    HTTP: request$,
+  };
+}
+```
+
+`drivers` is an object where each key matches a sink and source channel. Driver
+functions receive a sink stream and return a source:
+
+```js
+const drivers = {
+  DOM: makeDOMDriver('#app'),
+  HTTP: makeHTTPDriver(),
+};
+```
+
+The `DOM` sink is consumed by the DOM driver and `sources.DOM` is returned to
+`main`. The same pattern applies to every driver.
+
+## setup()
+
+Use `setup()` when you need access to `sources` and `sinks` before starting the
+program. This is useful in tests, integration code, or custom bootstrapping.
+
+```js
+import {setup} from '@cycle/run';
+
+const {sources, sinks, run} = setup(main, drivers);
+
+// Inspect sources or sinks here before the program starts.
+
+const dispose = run();
+```
+
+Unlike `run(main, drivers)`, `setup(main, drivers)` does not start execution
+until you call the returned `run()` function.
+
+## setupReusable()
+
+Use `setupReusable()` when you want to create driver sources once and run
+multiple sink collections through the same driver set.
+
+```js
+import {setupReusable} from '@cycle/run';
+
+const engine = setupReusable(drivers);
+
+const firstDispose = engine.run(firstMain(engine.sources));
+firstDispose();
+
+const secondDispose = engine.run(secondMain(engine.sources));
+secondDispose();
+
+engine.dispose();
+```
+
+Call `engine.dispose()` when you are done reusing those drivers.
+
+## xstream expectations
+
+`@cycle/run` expects sink streams to be xstream streams. If you use another
+stream library for your application code, use `@cycle/rxjs-run` or
+`@cycle/most-run` instead so that source and sink streams are adapted correctly.
 
 # API

--- a/docs/content/api/rxjs-run.md
+++ b/docs/content/api/rxjs-run.md
@@ -11,9 +11,81 @@ npm install @cycle/rxjs-run rxjs
 ## Basic usage
 
 ```js
-import run from '@cycle/rxjs-run'
+import run from '@cycle/rxjs-run';
+import {button} from '@cycle/dom';
 
-run(main, drivers)
+function main(sources) {
+  const action$ = sources.DOM.select('button').events('click');
+  const count$ = action$.scan(count => count + 1, 0).startWith(0);
+
+  return {
+    DOM: count$.map(count => button(String(count))),
+  };
+}
+
+const dispose = run(main, drivers);
 ```
+
+`run()` immediately starts the application and returns a dispose function. Call
+that function when the application should stop listening to sources, stop
+replicating sinks to drivers, and release driver resources.
+
+```js
+const dispose = run(main, drivers);
+
+// Later:
+dispose();
+```
+
+## Main and drivers
+
+`main` receives driver sources as RxJS observables and returns sinks as RxJS
+observables:
+
+```js
+function main(sources) {
+  return {
+    DOM: vdom$,
+    HTTP: request$,
+  };
+}
+```
+
+`drivers` is still an object where each key matches a sink and source channel:
+
+```js
+const drivers = {
+  DOM: makeDOMDriver('#app'),
+  HTTP: makeHTTPDriver(),
+};
+```
+
+Internally, `@cycle/rxjs-run` delegates to `@cycle/run` and adapts between
+xstream streams used by drivers and RxJS observables used by the application.
+
+## setup()
+
+Use `setup()` when you need access to `sources` and `sinks` before starting the
+program. This is useful in tests, integration code, or custom bootstrapping.
+
+```js
+import {setup} from '@cycle/rxjs-run';
+
+const {sources, sinks, run} = setup(main, drivers);
+
+// Inspect sources or sinks here before the program starts.
+
+const dispose = run();
+```
+
+Unlike `run(main, drivers)`, `setup(main, drivers)` does not start execution
+until you call the returned `run()` function.
+
+## RxJS expectations
+
+Use `@cycle/rxjs-run` when your `main` function is written with RxJS streams.
+Driver packages such as `@cycle/dom` and `@cycle/http` can still be the same
+official drivers; this package handles the stream adaptation at the app
+boundary.
 
 # API


### PR DESCRIPTION
/claim #851

Contributes to #851.

This adds another focused docs-revamp slice for the Cycle.js run packages. It expands the API pages for `@cycle/run`, `@cycle/rxjs-run`, and `@cycle/most-run` with:

- clearer `run(main, drivers)` lifecycle guidance
- dispose-function usage
- explanations of the `main`/`drivers` source-sink contract
- `setup()` examples for delayed startup and testing/integration code
- `setupReusable()` guidance for `@cycle/run`
- stream-library expectations and adaptation notes for xstream, RxJS, and most.js
- mirrored updates in the checked-in HTML wrappers for each page

Verification run locally:
- `node --check .scripts/make-api-docs.js`
- `git diff --check`
- embedded-markdown consistency checks for `run`, `rxjs-run`, and `most-run`

I also tried regenerating the rendered API HTML with:
- `node .scripts/make-api-docs.js run`

That fails in the existing docs toolchain because the installed GitHub tarball for `dox` throws `TypeError: parse is not a function`, matching the same pre-existing generator failure seen on the other docs-revamp branches.