### PR TITLE
docs: add DevTool guide

### DIFF
--- a/docs/.scripts/make-documentation.js
+++ b/docs/.scripts/make-documentation.js
@@ -12,6 +12,7 @@ var chapters = [
   {id: 'model-view-intent', title: 'Model-View-Intent'},
   {id: 'components', title: 'Components'},
   {id: 'drivers', title: 'Drivers'},
+  {id: 'devtool', title: 'DevTool'},
 ]
 
 chapters.forEach(function (chapter, i) {

--- a/docs/basic-examples.html
+++ b/docs/basic-examples.html
@@ -126,7 +126,7 @@ We do that by using `sources.DOM`, mapping `change` events on the checkbox to th
 
 ```diff
  import xs from 'xstream';
- import {run} from '@cycle/run';
+â€‚import {run} from '@cycle/run';
  import {div, input, p, makeDOMDriver} from '@cycle/dom';
 
  function main(sources) {
@@ -229,7 +229,7 @@ function main(sources) {
 However, initially, there won't be any `user$` event, because those only happen when the user clicks. This is the same "conversation initiative" problem we saw in the previous "checkbox" example. So we need to make `user$` start with a `null` user, and in case `vdom$` sees a null user, it renders just the button. Otherwise, if we have real user data, we also display their name, their email, and website.
 
 ```diff
- function main(sources) {
+â€‚function main(sources) {
    // ...
 
    const user$ = sources.HTTP.select('users')
@@ -560,7 +560,7 @@ We need a proper architecture for user interfaces that follows the reactive, fun
 
 <body role='flatdoc' class="no-literate">
 
-  
+
 
   <div class='header'>
     <div class='left'>
@@ -583,35 +583,37 @@ We need a proper architecture for user interfaces that follows the reactive, fun
   <div class='content-root'>
     <div class='menubar'>
       <div class='menu section'>
-        
+
         <ul>
-          
+
           <li><a href="getting-started.html" class="level-1 out-link">Getting started</a></li>
-          
+
           <li><a href="dialogue.html" class="level-1 out-link">Dialogue abstraction</a></li>
-          
+
           <li><a href="streams.html" class="level-1 out-link">Streams</a></li>
-          
+
         </ul>
-        
+
         <div role='flatdoc-menu'></div>
-        
+
         <ul>
-          
+
           <li><a href="model-view-intent.html" class="level-1 out-link">Model-View-Intent</a></li>
-          
+
           <li><a href="components.html" class="level-1 out-link">Components</a></li>
-          
+
           <li><a href="drivers.html" class="level-1 out-link">Drivers</a></li>
-          
+
+          <li><a href="devtool.html" class="level-1 out-link">DevTool</a></li>
+
         </ul>
-        
+
       </div>
     </div>
     <div role='flatdoc-content' class='content'></div>
-    
+
   </div>
-  
+
 
   <script>
     ((window.gitter = {}).chat = {}).options = {

--- a/docs/components.html
+++ b/docs/components.html
@@ -86,7 +86,7 @@ Remember that even though we are building a component, we are assuming our label
 The other input to this labeled slider program is the DOM source representing user events:
 
 ```diff
- function main(sources) {
+â€‚function main(sources) {
 +  const domSource = sources.DOM;
    const props$ = sources.props;
    // ...
@@ -143,7 +143,7 @@ function main(sources) {
 You might have noticed that besides the virtual DOM output, we also return the `value$` stream as a sink:
 
 ```diff
-   // ...
+â€‚â€‚â€‚// ...
    const sinks = {
      DOM: vdom$,
 +    value: value$,
@@ -242,7 +242,7 @@ As a result, we get a Cycle.js program where the labeled slider controls the siz
 
 Our labeled sliders were originally built for the BMI example, so we should see how the component we just built can be used in the BMI example.
 
-The naïve approach is to simply call `LabeledSlider()` twice, once with props for weight, and again with props for height:
+The naÃ¯ve approach is to simply call `LabeledSlider()` twice, once with props for weight, and again with props for height:
 
 <a class="jsbin-embed" href="//jsbin.com/lagegax/embed?output">JS Bin on jsbin.com</a>
 
@@ -317,7 +317,7 @@ In order to achieve these properties, we need to modify the sources when they en
 For the DOM source and DOM sink, we can use a unique identifier string as namespace for the virtual DOM element. First, we patch the DOM sink, adding a className to the VNodes it emits.
 
 ```diff
- function main(sources) {
+â€‚function main(sources) {
    // ...
 
    const weightSlider = LabeledSlider(weightSources);
@@ -357,7 +357,7 @@ In the context of the labeled slider component, **`sources.DOM.select()` should 
 We can achieve that by narrowing down the DOM source before it is given to the component, using the same className we patched on the sink, like this:
 
 ```diff
- function main(sources) {
+â€‚function main(sources) {
    // ...
    const weightSources = {
 -    DOM: sources.DOM,
@@ -414,7 +414,7 @@ function main(sources) {
 To avoid repeating code, such as the `.map(vnode => ...)` which patches the VNode, we could extract the functionality into functions: `isolateDOMSink()` and `isolateDOMSource()`.
 
 ```diff
- function main(sources) {
+â€‚function main(sources) {
    // ...
    const weightSources = {
 -    DOM: sources.DOM.select('.weight'), props: weightProps$
@@ -496,7 +496,7 @@ function isolate(Component, scope) {
 This allows us to simplify the `main()` function with two labeled slider components:
 
 ```diff
- function main(sources) {
+â€‚function main(sources) {
    const weightProps$ = xs.of({
      label: 'Weight', unit: 'kg', min: 40, value: 70, max: 150
    });
@@ -566,10 +566,10 @@ This does the same as previously, except the scope parameter is unique and autog
 >
 > Since Cycle.js follows functional programming techniques, usually most of its API is referentially transparent. `isolate()` is an exception, for convenience. If you want referential transparency everwhere, then provide explicit scope parameters. If you want convenience and you know how `isolate()` works, then use implicit scope parameters.
 
-If we compare our last code with the code we initially started out naïvely for `main()` to make the BMI calculator, the only difference is the use of `isolate()` on child components:
+If we compare our last code with the code we initially started out naÃ¯vely for `main()` to make the BMI calculator, the only difference is the use of `isolate()` on child components:
 
 ```diff
- function main(sources) {
+â€‚function main(sources) {
    const weightProps$ = xs.of({
      label: 'Weight', unit: 'kg', min: 40, value: 70, max: 150
    });
@@ -647,7 +647,7 @@ Each driver should define static functions `isolateSource` and `isolateSink`. We
 
 <body role='flatdoc' class="no-literate">
 
-  
+
 
   <div class='header'>
     <div class='left'>
@@ -670,35 +670,37 @@ Each driver should define static functions `isolateSource` and `isolateSink`. We
   <div class='content-root'>
     <div class='menubar'>
       <div class='menu section'>
-        
+
         <ul>
-          
+
           <li><a href="getting-started.html" class="level-1 out-link">Getting started</a></li>
-          
+
           <li><a href="dialogue.html" class="level-1 out-link">Dialogue abstraction</a></li>
-          
+
           <li><a href="streams.html" class="level-1 out-link">Streams</a></li>
-          
+
           <li><a href="basic-examples.html" class="level-1 out-link">Basic examples</a></li>
-          
+
           <li><a href="model-view-intent.html" class="level-1 out-link">Model-View-Intent</a></li>
-          
+
         </ul>
-        
+
         <div role='flatdoc-menu'></div>
-        
+
         <ul>
-          
+
           <li><a href="drivers.html" class="level-1 out-link">Drivers</a></li>
-          
+
+          <li><a href="devtool.html" class="level-1 out-link">DevTool</a></li>
+
         </ul>
-        
+
       </div>
     </div>
     <div role='flatdoc-content' class='content'></div>
-    
+
   </div>
-  
+
 
   <script>
     ((window.gitter = {}).chat = {}).options = {

--- a/docs/content/documentation/devtool.md
+++ b/docs/content/documentation/devtool.md
@@ -1,0 +1,59 @@
+# DevTool
+
+The Cycle.js DevTool is a Chrome DevTools panel for inspecting the dataflow graph of a Cycle.js application. It visualizes the streams that connect your sources and sinks, then animates events as they move through the graph.
+
+This is useful when an app has many streams or nested components and reading the code alone is not enough to understand why a sink receives a value.
+
+![Cycle.js DevTool graph](img/devtool.png)
+
+## Requirements
+
+The DevTool observes xstream debug listeners exposed by Cycle.js packages. Your app should use:
+
+- `xstream` v6.1.x or higher
+- `@cycle/run` v3.1.x or higher
+- `@cycle/dom` v12.2.x or higher when the app uses the DOM driver
+- `@cycle/http` v10.2.x or higher when the app uses the HTTP driver
+
+The graph serializer expects sink streams to be xstream streams. If an inspected app is using another stream library through `@cycle/rxjs-run` or `@cycle/most-run`, the DevTool may not be able to display the graph.
+
+## Install from Chrome Web Store
+
+Install the [Cycle.js Chrome extension](https://chrome.google.com/webstore/detail/cyclejs/dfgplfmhhmdekalbpejekgfegkonjpfp), open the app you want to inspect, then open Chrome DevTools. A **Cycle.js** panel appears next to the other DevTools panels.
+
+If the panel is blank while inspecting an app loaded from `file://`, open `chrome://extensions/`, find the Cycle.js extension, and enable **Allow access to file URLs**.
+
+## Build from source
+
+You can also build the extension from this repository:
+
+```bash
+cd devtool
+npm run dist
+```
+
+This compiles the extension into `devtool/dist` and creates `cyclejs-devtool.zip`. To load the unpacked build in Chrome:
+
+1. Open `chrome://extensions/`.
+2. Enable **Developer mode**.
+3. Choose **Load unpacked**.
+4. Select the `devtool/dist` directory.
+
+## Inspect an app
+
+After opening the **Cycle.js** DevTools panel, reload the inspected page so the extension can inject its graph serializer before the app starts.
+
+The graph shows sources and sinks as named boundary nodes. Operators and intermediate streams appear between them, so you can follow how values move from effects into the app and back out to drivers.
+
+Use the speed controls in the panel to slow down or speed up event animations when the app emits many values.
+
+## Troubleshooting
+
+If no graph appears:
+
+- Confirm the app uses supported versions of `xstream`, `@cycle/run`, and the drivers listed above.
+- Reload the inspected page after opening the DevTools panel.
+- Check that Chrome is allowed to access `file://` URLs when inspecting a local static page.
+- Make sure the app is not running with a production build that strips the debug hooks the DevTool relies on.
+
+If the graph appears but events do not animate, interact with the app after the panel is open. The DevTool only animates events it observes while connected to the inspected page.

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -86,7 +86,7 @@ function main(sources) {
 }
 ```
 
-In many frameworks the flow of data is *implicit*: you need to build a mental model of how data moves around in your app. In Cycle.js, the flow of data is clear by reading your code. The dataflow graph can also be viewed in the [Cycle.js DevTool for Chrome](https://github.com/cyclejs/cyclejs/tree/master/devtool), which shows data moving in real-time through the graph:
+In many frameworks the flow of data is *implicit*: you need to build a mental model of how data moves around in your app. In Cycle.js, the flow of data is clear by reading your code. The dataflow graph can also be viewed in the [Cycle.js DevTool for Chrome](devtool.html), which shows data moving in real-time through the graph:
 
 <p>
   <img src="img/devtool.png" style="max-height:inherit">

--- a/docs/devtool.html
+++ b/docs/devtool.html
@@ -1,0 +1,172 @@
+<!doctype html>
+<html>
+
+<head>
+  <meta charset='utf-8'>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <meta name="viewport" content="width=device-width">
+  <title>Cycle.js - DevTool</title>
+
+  <!-- Flatdoc -->
+  <script src='support/vendor/jquery.js'></script>
+  <script src='support/vendor/highlight.pack.js'></script>
+  <script src='legacy.js'></script>
+  <script src='flatdoc.js'></script>
+
+  <!-- Algolia's DocSearch main theme -->
+  <link href='//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css' rel='stylesheet' />
+
+  <!-- Others -->
+  <script async src="//static.jsbin.com/js/embed.js"></script>
+
+  <!-- Flatdoc theme -->
+  <link href='theme/style.css' rel='stylesheet'>
+  <script src='theme/script.js'></script>
+  <link href='support/vendor/highlight-github-gist.css' rel='stylesheet'>
+
+  <!-- Meta -->
+  <meta content="Cycle.js - DevTool" property="og:title">
+  <meta content="A functional and reactive JavaScript framework for predictable code" name="description">
+
+  <!-- Content -->
+  <script id="markdown" type="text/markdown" src="index.html">
+# DevTool
+
+The Cycle.js DevTool is a Chrome DevTools panel for inspecting the dataflow graph of a Cycle.js application. It visualizes the streams that connect your sources and sinks, then animates events as they move through the graph.
+
+This is useful when an app has many streams or nested components and reading the code alone is not enough to understand why a sink receives a value.
+
+![Cycle.js DevTool graph](img/devtool.png)
+
+## Requirements
+
+The DevTool observes xstream debug listeners exposed by Cycle.js packages. Your app should use:
+
+- `xstream` v6.1.x or higher
+- `@cycle/run` v3.1.x or higher
+- `@cycle/dom` v12.2.x or higher when the app uses the DOM driver
+- `@cycle/http` v10.2.x or higher when the app uses the HTTP driver
+
+The graph serializer expects sink streams to be xstream streams. If an inspected app is using another stream library through `@cycle/rxjs-run` or `@cycle/most-run`, the DevTool may not be able to display the graph.
+
+## Install from Chrome Web Store
+
+Install the [Cycle.js Chrome extension](https://chrome.google.com/webstore/detail/cyclejs/dfgplfmhhmdekalbpejekgfegkonjpfp), open the app you want to inspect, then open Chrome DevTools. A **Cycle.js** panel appears next to the other DevTools panels.
+
+If the panel is blank while inspecting an app loaded from `file://`, open `chrome://extensions/`, find the Cycle.js extension, and enable **Allow access to file URLs**.
+
+## Build from source
+
+You can also build the extension from this repository:
+
+```bash
+cd devtool
+npm run dist
+```
+
+This compiles the extension into `devtool/dist` and creates `cyclejs-devtool.zip`. To load the unpacked build in Chrome:
+
+1. Open `chrome://extensions/`.
+2. Enable **Developer mode**.
+3. Choose **Load unpacked**.
+4. Select the `devtool/dist` directory.
+
+## Inspect an app
+
+After opening the **Cycle.js** DevTools panel, reload the inspected page so the extension can inject its graph serializer before the app starts.
+
+The graph shows sources and sinks as named boundary nodes. Operators and intermediate streams appear between them, so you can follow how values move from effects into the app and back out to drivers.
+
+Use the speed controls in the panel to slow down or speed up event animations when the app emits many values.
+
+## Troubleshooting
+
+If no graph appears:
+
+- Confirm the app uses supported versions of `xstream`, `@cycle/run`, and the drivers listed above.
+- Reload the inspected page after opening the DevTools panel.
+- Check that Chrome is allowed to access `file://` URLs when inspecting a local static page.
+- Make sure the app is not running with a production build that strips the debug hooks the DevTool relies on.
+
+If the graph appears but events do not animate, interact with the app after the panel is open. The DevTool only animates events it observes while connected to the inspected page.
+
+  </script>
+
+  <!-- Initializer -->
+  <script>
+    Flatdoc.run({
+      fetcher: function (callback) {
+        callback(null, document.getElementById('markdown').innerHTML);
+      },
+      highlight: function (code, value) {
+        return hljs.highlight(value, code).value;
+      },
+    });
+  </script>
+
+</head>
+
+<body role='flatdoc' class="no-literate">
+
+
+
+  <div class='header'>
+    <div class='left'>
+      <h1><a href="/"><img class="logo" src="img/cyclejs_logo.svg">Cycle.js</a></h1>
+      <ul>
+        <li><a href='getting-started.html'>Guide</a></li>
+        <li><a href='api/index.html'>API</a></li>
+        <li><a href='releases.html'>Releases</a></li>
+        <li><a href='https://github.com/cyclejs/cyclejs'>GitHub</a></li>
+      </ul>
+      <input id="docsearch" />
+    </div>
+    <div class='right'>
+      <!-- GitHub buttons: see https://ghbtns.com -->
+      <iframe src="https://ghbtns.com/github-btn.html?user=cyclejs&amp;repo=cyclejs&amp;type=watch&amp;count=true"
+        allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
+    </div>
+  </div>
+
+  <div class='content-root'>
+    <div class='menubar'>
+      <div class='menu section'>
+
+        <ul>
+
+          <li><a href="getting-started.html" class="level-1 out-link">Getting started</a></li>
+
+          <li><a href="dialogue.html" class="level-1 out-link">Dialogue abstraction</a></li>
+
+          <li><a href="streams.html" class="level-1 out-link">Streams</a></li>
+
+          <li><a href="basic-examples.html" class="level-1 out-link">Basic examples</a></li>
+
+          <li><a href="model-view-intent.html" class="level-1 out-link">Model-View-Intent</a></li>
+
+          <li><a href="components.html" class="level-1 out-link">Components</a></li>
+
+          <li><a href="drivers.html" class="level-1 out-link">Drivers</a></li>
+
+        </ul>
+
+        <div role='flatdoc-menu'></div>
+
+      </div>
+    </div>
+    <div role='flatdoc-content' class='content'></div>
+
+  </div>
+
+
+  <script>
+    ((window.gitter = {}).chat = {}).options = {
+      room: 'cyclejs/cyclejs'
+    };
+  </script>
+  <script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
+  <script src='//cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js'></script>
+  <script src='docsearch.js'></script>
+</body>
+
+</html>

--- a/docs/dialogue.html
+++ b/docs/dialogue.html
@@ -130,7 +130,7 @@ These are questions that drive the core architecture of Cycle.js, but to underst
 
 <body role='flatdoc' class="no-literate">
 
-  
+
 
   <div class='header'>
     <div class='left'>
@@ -153,35 +153,37 @@ These are questions that drive the core architecture of Cycle.js, but to underst
   <div class='content-root'>
     <div class='menubar'>
       <div class='menu section'>
-        
+
         <ul>
-          
+
           <li><a href="getting-started.html" class="level-1 out-link">Getting started</a></li>
-          
+
         </ul>
-        
+
         <div role='flatdoc-menu'></div>
-        
+
         <ul>
-          
+
           <li><a href="streams.html" class="level-1 out-link">Streams</a></li>
-          
+
           <li><a href="basic-examples.html" class="level-1 out-link">Basic examples</a></li>
-          
+
           <li><a href="model-view-intent.html" class="level-1 out-link">Model-View-Intent</a></li>
-          
+
           <li><a href="components.html" class="level-1 out-link">Components</a></li>
-          
+
           <li><a href="drivers.html" class="level-1 out-link">Drivers</a></li>
-          
+
+          <li><a href="devtool.html" class="level-1 out-link">DevTool</a></li>
+
         </ul>
-        
+
       </div>
     </div>
     <div role='flatdoc-content' class='content'></div>
-    
+
   </div>
-  
+
 
   <script>
     ((window.gitter = {}).chat = {}).options = {

--- a/docs/drivers.html
+++ b/docs/drivers.html
@@ -334,7 +334,7 @@ As a framework, it cannot be compared to monoliths which have ruled web developm
 
 <body role='flatdoc' class="no-literate">
 
-  
+
 
   <div class='header'>
     <div class='left'>
@@ -357,31 +357,37 @@ As a framework, it cannot be compared to monoliths which have ruled web developm
   <div class='content-root'>
     <div class='menubar'>
       <div class='menu section'>
-        
+
         <ul>
-          
+
           <li><a href="getting-started.html" class="level-1 out-link">Getting started</a></li>
-          
+
           <li><a href="dialogue.html" class="level-1 out-link">Dialogue abstraction</a></li>
-          
+
           <li><a href="streams.html" class="level-1 out-link">Streams</a></li>
-          
+
           <li><a href="basic-examples.html" class="level-1 out-link">Basic examples</a></li>
-          
+
           <li><a href="model-view-intent.html" class="level-1 out-link">Model-View-Intent</a></li>
-          
+
           <li><a href="components.html" class="level-1 out-link">Components</a></li>
-          
+
         </ul>
-        
+
         <div role='flatdoc-menu'></div>
-        
+
+        <ul>
+
+          <li><a href="devtool.html" class="level-1 out-link">DevTool</a></li>
+
+        </ul>
+
       </div>
     </div>
     <div role='flatdoc-content' class='content'></div>
-    
+
   </div>
-  
+
 
   <script>
     ((window.gitter = {}).chat = {}).options = {

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -253,7 +253,7 @@ function main(sources) {
 
 <body role='flatdoc' class="no-literate">
 
-  
+
 
   <div class='header'>
     <div class='left'>
@@ -276,31 +276,33 @@ function main(sources) {
   <div class='content-root'>
     <div class='menubar'>
       <div class='menu section'>
-        
+
         <div role='flatdoc-menu'></div>
-        
+
         <ul>
-          
+
           <li><a href="dialogue.html" class="level-1 out-link">Dialogue abstraction</a></li>
-          
+
           <li><a href="streams.html" class="level-1 out-link">Streams</a></li>
-          
+
           <li><a href="basic-examples.html" class="level-1 out-link">Basic examples</a></li>
-          
+
           <li><a href="model-view-intent.html" class="level-1 out-link">Model-View-Intent</a></li>
-          
+
           <li><a href="components.html" class="level-1 out-link">Components</a></li>
-          
+
           <li><a href="drivers.html" class="level-1 out-link">Drivers</a></li>
-          
+
+          <li><a href="devtool.html" class="level-1 out-link">DevTool</a></li>
+
         </ul>
-        
+
       </div>
     </div>
     <div role='flatdoc-content' class='content'></div>
-    
+
   </div>
-  
+
 
   <script>
     ((window.gitter = {}).chat = {}).options = {

--- a/docs/index.html
+++ b/docs/index.html
@@ -118,7 +118,7 @@ function main(sources) {
 }
 ```
 
-In many frameworks the flow of data is *implicit*: you need to build a mental model of how data moves around in your app. In Cycle.js, the flow of data is clear by reading your code. The dataflow graph can also be viewed in the [Cycle.js DevTool for Chrome](https://github.com/cyclejs/cyclejs/tree/master/devtool), which shows data moving in real-time through the graph:
+In many frameworks the flow of data is *implicit*: you need to build a mental model of how data moves around in your app. In Cycle.js, the flow of data is clear by reading your code. The dataflow graph can also be viewed in the [Cycle.js DevTool for Chrome](devtool.html), which shows data moving in real-time through the graph:
 
 <p>
   <img src="img/devtool.png" style="max-height:inherit">
@@ -174,7 +174,7 @@ Got 1 hour and 32 minutes? That is all it takes to learn the essentials of Cycle
 
 <body role='flatdoc' class="no-literate">
 
-  
+
   <div class="hero">
     <div class="hero-body">
       <div class="hero-title">
@@ -188,7 +188,7 @@ Got 1 hour and 32 minutes? That is all it takes to learn the essentials of Cycle
       -->
     </div>
   </div>
-  
+
 
   <div class='header'>
     <div class='left'>
@@ -211,21 +211,21 @@ Got 1 hour and 32 minutes? That is all it takes to learn the essentials of Cycle
   <div class='content-root'>
     <div class='menubar'>
       <div class='menu section'>
-        
+
         <div role='flatdoc-menu'></div>
-        
+
       </div>
     </div>
     <div role='flatdoc-content' class='content'></div>
-    
+
     <div class='content'>
       <script src="https://opencollective.com/cyclejs/banner.js"></script>
     </div>
-    
+
   </div>
-  
+
   <script src="js/example-hello-world.min.js" async defer></script>
-  
+
 
   <script>
     ((window.gitter = {}).chat = {}).options = {

--- a/docs/model-view-intent.html
+++ b/docs/model-view-intent.html
@@ -98,7 +98,7 @@ We have plenty of anonymous functions which could be refactored away from `main`
 
 ```diff
  import xs from 'xstream';
- import {run} from '@cycle/run';
+â€‚import {run} from '@cycle/run';
  import {div, input, h2, makeDOMDriver} from '@cycle/dom';
 
 +function renderWeightSlider(weight) {
@@ -178,7 +178,7 @@ We have plenty of anonymous functions which could be refactored away from `main`
 
 ```diff
  import xs from 'xstream';
- import {run} from '@cycle/run';
+â€‚import {run} from '@cycle/run';
  import {div, input, h2, makeDOMDriver} from '@cycle/dom';
 
  function renderWeightSlider(weight) {
@@ -254,7 +254,7 @@ Now, `main` is much smaller. But is it doing *one thing*? We still have `changeW
 
 ```diff
  import xs from 'xstream';
- import {run} from '@cycle/run';
+â€‚import {run} from '@cycle/run';
  import {div, input, h2, makeDOMDriver} from '@cycle/dom';
 
  // ...
@@ -313,7 +313,7 @@ Now, `main` is much smaller. But is it doing *one thing*? We still have `changeW
 
 ```diff
  import xs from 'xstream';
- import {run} from '@cycle/run';
+â€‚import {run} from '@cycle/run';
  import {div, input, h2, makeDOMDriver} from '@cycle/dom';
 
  // ...
@@ -540,7 +540,7 @@ But this still isn't ideal: we seem to have *more* code now. What we really want
 
 <body role='flatdoc' class="no-literate">
 
-  
+
 
   <div class='header'>
     <div class='left'>
@@ -563,35 +563,37 @@ But this still isn't ideal: we seem to have *more* code now. What we really want
   <div class='content-root'>
     <div class='menubar'>
       <div class='menu section'>
-        
+
         <ul>
-          
+
           <li><a href="getting-started.html" class="level-1 out-link">Getting started</a></li>
-          
+
           <li><a href="dialogue.html" class="level-1 out-link">Dialogue abstraction</a></li>
-          
+
           <li><a href="streams.html" class="level-1 out-link">Streams</a></li>
-          
+
           <li><a href="basic-examples.html" class="level-1 out-link">Basic examples</a></li>
-          
+
         </ul>
-        
+
         <div role='flatdoc-menu'></div>
-        
+
         <ul>
-          
+
           <li><a href="components.html" class="level-1 out-link">Components</a></li>
-          
+
           <li><a href="drivers.html" class="level-1 out-link">Drivers</a></li>
-          
+
+          <li><a href="devtool.html" class="level-1 out-link">DevTool</a></li>
+
         </ul>
-        
+
       </div>
     </div>
     <div role='flatdoc-content' class='content'></div>
-    
+
   </div>
-  
+
 
   <script>
     ((window.gitter = {}).chat = {}).options = {

--- a/docs/streams.html
+++ b/docs/streams.html
@@ -218,7 +218,7 @@ Next, read the [basic examples](basic-examples.html) which apply what we've lear
 
 <body role='flatdoc' class="no-literate">
 
-  
+
 
   <div class='header'>
     <div class='left'>
@@ -241,35 +241,37 @@ Next, read the [basic examples](basic-examples.html) which apply what we've lear
   <div class='content-root'>
     <div class='menubar'>
       <div class='menu section'>
-        
+
         <ul>
-          
+
           <li><a href="getting-started.html" class="level-1 out-link">Getting started</a></li>
-          
+
           <li><a href="dialogue.html" class="level-1 out-link">Dialogue abstraction</a></li>
-          
+
         </ul>
-        
+
         <div role='flatdoc-menu'></div>
-        
+
         <ul>
-          
+
           <li><a href="basic-examples.html" class="level-1 out-link">Basic examples</a></li>
-          
+
           <li><a href="model-view-intent.html" class="level-1 out-link">Model-View-Intent</a></li>
-          
+
           <li><a href="components.html" class="level-1 out-link">Components</a></li>
-          
+
           <li><a href="drivers.html" class="level-1 out-link">Drivers</a></li>
-          
+
+          <li><a href="devtool.html" class="level-1 out-link">DevTool</a></li>
+
         </ul>
-        
+
       </div>
     </div>
     <div role='flatdoc-content' class='content'></div>
-    
+
   </div>
-  
+
 
   <script>
     ((window.gitter = {}).chat = {}).options = {


### PR DESCRIPTION
Part of #851.

This adds a dedicated DevTool documentation page to the site guide, covering:

- what the Chrome DevTool visualizes
- supported package/version requirements
- Chrome Web Store installation
- local extension build/load steps
- inspection workflow and common troubleshooting

It also adds the page to the generated Guide navigation and updates the homepage DevTool link to point to the local docs page instead of the package directory.

Verification:

- `node docs\.scripts\make-index.js`
- `node docs\.scripts\make-documentation.js`
- `git diff --check`