### PR TITLE
fix(http): support browser File attachments

### DIFF
--- a/http/src/http-driver.ts
+++ b/http/src/http-driver.ts
@@ -19,6 +19,22 @@ function preprocessReqOptions(reqOptions: RequestOptions): RequestOptions {
   return reqOptions;
 }
 
+function isFileAttachment(attachment: any): attachment is File {
+  return (
+    typeof window !== 'undefined' &&
+    typeof File !== 'undefined' &&
+    attachment instanceof File
+  );
+}
+
+function isBlobAttachment(attachment: any): attachment is Blob {
+  return (
+    typeof window !== 'undefined' &&
+    typeof Blob !== 'undefined' &&
+    attachment instanceof Blob
+  );
+}
+
 export function optionsToSuperagent(rawReqOptions: RequestOptions) {
   const reqOptions = preprocessReqOptions(rawReqOptions);
   if (typeof reqOptions.url !== `string`) {
@@ -76,7 +92,13 @@ export function optionsToSuperagent(rawReqOptions: RequestOptions) {
   if (reqOptions.attach) {
     for (let i = reqOptions.attach.length - 1; i >= 0; i--) {
       const a = reqOptions.attach[i];
-      request = request.attach(a.name, a.path, a.filename);
+      if (isFileAttachment(a)) {
+        request = request.attach(a.name, a, a.name);
+      } else if (isBlobAttachment(a.file)) {
+        request = request.attach(a.name, a.file, a.filename);
+      } else {
+        request = request.attach(a.name, a.path, a.filename);
+      }
     }
   }
   if (reqOptions.responseType) {

--- a/http/src/index.ts
+++ b/http/src/index.ts
@@ -27,8 +27,9 @@
  * - `field` *(Object)*: object where key/values are Form fields.
  * - `progress` *(Boolean)*: whether or not to detect and emit progress events
  * on the response Observable.
- * - `attach` *(Array)*: array of objects, where each object specifies `name`,
- * `path`, and `filename` of a resource to upload.
+ * - `attach` *(Array)*: array of browser `File` objects or objects where each
+ * object specifies `name`, `path` or `file`, and `filename` of a resource to
+ * upload.
  * - `withCredentials` *(Boolean)*: enables the ability to send cookies from the
  * origin.
  * - `agent` *(Object)*: an object specifying `cert` and `key` for SSL

--- a/http/src/interfaces.ts
+++ b/http/src/interfaces.ts
@@ -1,9 +1,12 @@
 import {Stream, MemoryStream} from 'xstream';
 import {Response as SuperagentResponse} from 'superagent';
 
-export interface Attachment {
+export type Attachment = File | AttachmentOptions;
+
+export interface AttachmentOptions {
   name: string;
   path?: string;
+  file?: Blob;
   filename?: string;
 }
 

--- a/http/test/browser/common.ts
+++ b/http/test/browser/common.ts
@@ -8,6 +8,7 @@ import {
 } from '../../src/index';
 import {Stream} from 'xstream';
 import {HTTPSource, makeHTTPDriver} from '../../src/rxjs';
+import {optionsToSuperagent} from '../../src/http-driver';
 import {Observable, of, merge, Subject} from 'rxjs';
 import {mergeAll, switchMap, map, delay, shareReplay} from 'rxjs/operators';
 import {setup} from '@cycle/rxjs-run';
@@ -183,6 +184,40 @@ export function runTests(uri: string) {
         });
       });
       run();
+    });
+
+    it('should accept browser File objects in attach [#294]', function() {
+      if (typeof window === 'undefined' || typeof File === 'undefined') {
+        this.skip();
+      }
+
+      const file = new File(['hello world'], 'hello.txt', {
+        type: 'text/plain',
+      });
+      const request = optionsToSuperagent({
+        url: uri + '/pet',
+        method: 'POST',
+        attach: [file],
+      });
+
+      assert.strictEqual(typeof request.end, 'function');
+    });
+
+    it('should accept browser File objects wrapped in attach options [#294]', function() {
+      if (typeof window === 'undefined' || typeof File === 'undefined') {
+        this.skip();
+      }
+
+      const file = new File(['hello world'], 'hello.txt', {
+        type: 'text/plain',
+      });
+      const request = optionsToSuperagent({
+        url: uri + '/pet',
+        method: 'POST',
+        attach: [{name: 'file', file, filename: 'hello.txt'}],
+      });
+
+      assert.strictEqual(typeof request.end, 'function');
     });
 
     it('should have DevTools flag in select() source stream', function(done) {


### PR DESCRIPTION
Fixes #294.

The HTTP driver previously assumed every `attach` entry used the Node-style `{ name, path, filename }` shape, which breaks for browser `File` objects from `<input type=file>` because those objects have no `path` or `filename` property.

This keeps the existing Node path behavior and adds browser-only handling for:

- `attach: [file]`
- `attach: [{ name: 'file', file, filename: 'hello.txt' }]`

Node behavior is guarded so Node 22's global `File` does not accidentally take the browser path when using Node superagent.

Verification:

- `npm run lint --prefix http`
- `npx tsc --project http\\tsconfig.json --module commonjs --outDir http\\lib\\cjs`
- `npx tsc --project http\\tsconfig.json --module es6 --outDir http\\lib\\es6`
- `npm run test-node --prefix http` (26 passing, 2 browser-only tests pending in Node)
- ChromeHeadless `karma start http/karma.conf.js --browsers ChromeHeadless --single-run` with the HTTP support server running (28/28 passing)