### PR TITLE
docs(rxjs-run): add setup testing usage

### DIFF
--- a/docs/content/api/rxjs-run.md
+++ b/docs/content/api/rxjs-run.md
@@ -16,4 +16,29 @@ import run from '@cycle/rxjs-run'
 run(main, drivers)
 ```
 
+## Testing usage
+
+Use `setup()` when a test needs access to the application sources or sinks
+before the circular connection starts. This returns `{sources, sinks, run}`.
+The application only begins after `run()` is called, and `run()` returns the
+dispose function.
+
+```js
+import {setup} from '@cycle/rxjs-run'
+
+const {sources, sinks, run} = setup(main, drivers)
+
+let dispose
+
+sources.DOM.select(':root').elements()
+  .subscribe({
+    next: element => {
+      fn(element)
+      dispose()
+    },
+  })
+
+dispose = run() // start the loop
+```
+
 # API


### PR DESCRIPTION
Adds a testing-usage section to the @cycle/rxjs-run API docs, matching the existing @cycle/most-run guidance for using setup() before starting the circular connection.\n\nThis is another small docs-revamp contribution for #851.\n\nVerification:\n- node docs/.scripts/make-index.js\n- node docs/.scripts/make-documentation.js\n- git diff --check