### PR TITLE
docs(most-run): call elements in testing example

### DIFF
--- a/docs/content/api/most-run.md
+++ b/docs/content/api/most-run.md
@@ -25,7 +25,7 @@ const {sources, sinks, run} = setup(main, drivers)
 
 let dispose
 
-sources.DOM.select(':root').elements
+sources.DOM.select(':root').elements()
   .observe(fn)
   .then(() => dispose())
 


### PR DESCRIPTION
Fixes the @cycle/most-run testing example to call DOMSource.elements() as a method, matching the current DOMSource API.\n\nThis is another small docs-revamp contribution for #851.\n\nVerification:\n- node docs/.scripts/make-index.js\n- node docs/.scripts/make-documentation.js\n- git diff --check